### PR TITLE
feat(#2): 创建 .github/dependabot.yml，启用 Dependabot 自动依赖更新与安全扫描。配置 pip（Python 依赖）和 github-actions 两个生态系统的 weekly 自动更新，包含生产依赖分组、开发依赖分组、GitHub Actions 分组策略，以及 major 版本更新的忽略规则和 reviewer/label 配置。

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+# Dependabot configuration for automatic dependency updates and security scanning
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+
+updates:
+  # Python dependencies (managed via uv / pyproject.toml)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    # Group updates to reduce noise — one PR per update type
+    groups:
+      # Production dependencies: keep together to avoid compatibility issues
+      production-deps:
+        patterns:
+          - "claude-agent-sdk"
+          - "click"
+          - "pydantic"
+          - "tomli*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Dev / tooling dependencies: safe to batch
+      dev-deps:
+        patterns:
+          - "pytest*"
+          - "ruff"
+          - "mypy"
+        update-types:
+          - "minor"
+          - "patch"
+    # Ignore major version bumps for production deps — require manual review
+    ignore:
+      - dependency-name: "claude-agent-sdk"
+        update-types: ["version-update:major"]
+      - dependency-name: "pydantic"
+        update-types: ["version-update:major"]
+    labels:
+      - "dependencies"
+      - "python"
+    reviewers:
+      - "gqy20"
+    commit-message:
+      prefix: "deps"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"
+    open-pull-requests-limit: 5
+    # Group action updates together
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    reviewers:
+      - "gqy20"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary

创建 .github/dependabot.yml，启用 Dependabot 自动依赖更新与安全扫描。配置 pip（Python 依赖）和 github-actions 两个生态系统的 weekly 自动更新，包含生产依赖分组、开发依赖分组、GitHub Actions 分组策略，以及 major 版本更新的忽略规则和 reviewer/label 配置。

## Dispatch

ready-to-implement, priority=P2, complexity=S, created_at=2026-03-31T10:26:55Z

Closes #2