### PR TITLE
feat(#7): Add @gearbox as audit trigger keyword alongside @audit in audit workflow, so users can mention @gearbox in issues/comments to trigger repository audits

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -46,9 +46,9 @@ jobs:
     if: |
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'schedule') ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@audit') && github.event.comment.user.id != github.event.installation.id) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@audit') && github.event.comment.user.id != github.event.installation.id) ||
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@audit'))
+      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, '@audit') || contains(github.event.comment.body, '@gearbox')) && github.event.comment.user.id != github.event.installation.id) ||
+      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, '@audit') || contains(github.event.comment.body, '@gearbox')) && github.event.comment.user.id != github.event.installation.id) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@audit') || contains(github.event.issue.body, '@gearbox')))
     runs-on: ubuntu-latest
     outputs:
       repo: ${{ steps.target.outputs.repo }}


### PR DESCRIPTION
## Summary

Add @gearbox as audit trigger keyword alongside @audit in audit workflow, so users can mention @gearbox in issues/comments to trigger repository audits

## Dispatch

ready-to-implement, priority=P3, complexity=S, created_at=2026-04-26T14:53:08Z

Closes #7