### PR TITLE
feat(#13): 增强 parse_issue_numbers 支持 # 前缀解析并改善错误提示：支持 #12、#12, #13、12 #13,14 等格式；空白输入返回空列表；非法 token 抛出带具体 token 信息的 ValueError；新增 5 个测试用例覆盖所有场景

### DIFF
--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -72,8 +72,30 @@ class BacklogResult:
 
 
 def parse_issue_numbers(value: str) -> list[int]:
-    """Parse comma/space separated issue numbers."""
-    numbers = [int(part) for part in re.split(r"[\s,]+", value.strip()) if part]
+    """Parse comma/space separated issue numbers, supporting ``#`` prefix.
+
+    Accepts inputs like ``#12``, ``#12, #13``, ``12 #13,14``.
+    Returns an empty list for blank input.
+    Raises :class:`ValueError` with a helpful message when a token
+    cannot be parsed as an issue number.
+    """
+    stripped = value.strip()
+    if not stripped:
+        return []
+
+    raw_tokens: list[str] = re.split(r"[\s,]+", stripped)
+    tokens = [t for t in raw_tokens if t]
+
+    numbers: list[int] = []
+    for token in tokens:
+        cleaned = token.lstrip("#")
+        try:
+            numbers.append(int(cleaned))
+        except ValueError as exc:
+            raise ValueError(
+                f"无法解析 issue 编号: '{token}' (非法 token)"
+            ) from exc
+
     return list(dict.fromkeys(numbers))
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
 
 from gearbox.agents import backlog, implement
@@ -142,6 +143,26 @@ class TestStructuredOutputParsing:
 
     def test_parse_issue_numbers(self) -> None:
         assert parse_issue_numbers("2, 5 6") == [2, 5, 6]
+
+    def test_parse_issue_numbers_hash_prefix(self) -> None:
+        assert parse_issue_numbers("#12") == [12]
+        assert parse_issue_numbers("#12, #13") == [12, 13]
+        assert parse_issue_numbers("12 #13,14") == [12, 13, 14]
+
+    def test_parse_issue_numbers_empty_input(self) -> None:
+        assert parse_issue_numbers("") == []
+        assert parse_issue_numbers("   ") == []
+
+    def test_parse_issue_numbers_dedup(self) -> None:
+        assert parse_issue_numbers("5, #5, 5") == [5]
+
+    def test_parse_issue_numbers_invalid_token(self) -> None:
+        with pytest.raises(ValueError, match="无法解析 issue 编号: 'abc'"):
+            parse_issue_numbers("12 abc")
+
+    def test_parse_issue_numbers_invalid_hash_token(self) -> None:
+        with pytest.raises(ValueError, match="无法解析 issue 编号: '#abc'"):
+            parse_issue_numbers("#abc")
 
     def test_backlog_result_contains_issue_items(self) -> None:
         result = BacklogResult(


### PR DESCRIPTION
## Summary

增强 parse_issue_numbers 支持 # 前缀解析并改善错误提示：支持 #12、#12, #13、12 #13,14 等格式；空白输入返回空列表；非法 token 抛出带具体 token 信息的 ValueError；新增 5 个测试用例覆盖所有场景

Closes #13