### PR TITLE
feat(#13): 增强 parse_issue_numbers 支持 # 前缀并改善错误提示：支持 #12、#12, #13、12 #13,14 等格式；空白输入返回空列表；非法 token 抛出带具体 token 的 ValueError；新增 7 个测试用例覆盖所有场景

### DIFF
--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -72,8 +72,35 @@ class BacklogResult:
 
 
 def parse_issue_numbers(value: str) -> list[int]:
-    """Parse comma/space separated issue numbers."""
-    numbers = [int(part) for part in re.split(r"[\s,]+", value.strip()) if part]
+    """Parse comma/space separated issue numbers, supporting ``#`` prefix.
+
+    Accepts inputs like ``#12``, ``#12, #13``, ``12 #13,14``.
+    Returns an empty list for blank input.
+    Raises :class:`ValueError` with a helpful message when a token
+    cannot be parsed as an integer.
+    """
+    if not value.strip():
+        return []
+
+    raw_tokens = re.split(r"[\s,]+", value.strip())
+    numbers: list[int] = []
+    bad_tokens: list[str] = []
+
+    for token in raw_tokens:
+        if not token:
+            continue
+        stripped = token.lstrip("#")
+        try:
+            numbers.append(int(stripped))
+        except ValueError:
+            bad_tokens.append(token)
+
+    if bad_tokens:
+        raise ValueError(
+            f"无法解析 issue 编号: {', '.join(repr(t) for t in bad_tokens)}。"
+            f"请使用数字或 #数字 格式，例如 '12, 13' 或 '#12 #13'"
+        )
+
     return list(dict.fromkeys(numbers))
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+import pytest
 from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
 
 from gearbox.agents import backlog, implement
@@ -140,8 +141,32 @@ class TestStructuredOutputParsing:
             "needs-clarification",
         ]
 
-    def test_parse_issue_numbers(self) -> None:
+    def test_parse_issue_numbers_basic(self) -> None:
         assert parse_issue_numbers("2, 5 6") == [2, 5, 6]
+
+    def test_parse_issue_numbers_hash_prefix_single(self) -> None:
+        assert parse_issue_numbers("#12") == [12]
+
+    def test_parse_issue_numbers_hash_prefix_multiple(self) -> None:
+        assert parse_issue_numbers("#12, #13") == [12, 13]
+
+    def test_parse_issue_numbers_mixed_format(self) -> None:
+        assert parse_issue_numbers("12 #13,14") == [12, 13, 14]
+
+    def test_parse_issue_numbers_empty_input(self) -> None:
+        assert parse_issue_numbers("") == []
+        assert parse_issue_numbers("   ") == []
+
+    def test_parse_issue_numbers_deduplication(self) -> None:
+        assert parse_issue_numbers("#3, 3, #3") == [3]
+
+    def test_parse_issue_numbers_invalid_token_raises_valueerror(self) -> None:
+        with pytest.raises(ValueError, match="无法解析 issue 编号: 'abc'"):
+            parse_issue_numbers("12 abc")
+
+    def test_parse_issue_numbers_invalid_token_shows_all_bad_tokens(self) -> None:
+        with pytest.raises(ValueError, match="无法解析 issue 编号: 'abc', 'xyz'"):
+            parse_issue_numbers("1 abc, xyz #4")
 
     def test_backlog_result_contains_issue_items(self) -> None:
         result = BacklogResult(


### PR DESCRIPTION
## Summary

增强 parse_issue_numbers 支持 # 前缀并改善错误提示：支持 #12、#12, #13、12 #13,14 等格式；空白输入返回空列表；非法 token 抛出带具体 token 的 ValueError；新增 7 个测试用例覆盖所有场景

Closes #13