### PR TITLE
feat(#12): 在 README.md 的"快速开始"与"当前架构"之间新增"本地验证"小节，包含 pytest、ruff check、mypy 三个提交前基本检查命令，文案简洁约 6 行

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ uv run gearbox config set anthropic-api-key YOUR_KEY
 uv run gearbox config list
 ```
 
+## 本地验证
+
+提交前可运行以下命令做基本检查：
+
+```bash
+uv run pytest
+uv run ruff check .
+uv run mypy src
+```
+
 ## 当前架构
 
 ```text


### PR DESCRIPTION
## Summary

在 README.md 的"快速开始"与"当前架构"之间新增"本地验证"小节，包含 pytest、ruff check、mypy 三个提交前基本检查命令，文案简洁约 6 行

Closes #12