### PR TITLE
feat(#17): 扩展 semgrep 扫描范围至纯 Python 项目，修复 Issue #17 安全盲区。将 scan_repository 中 semgrep 的项目类型条件从 ("typescript", "mixed") 扩展为 ("python", "typescript", "mixed")，使 Python 项目也能获得 OWASP Top 10、SQL 注入、命令注入等安全规则及代码质量规则的覆盖。同步更新测试用例验证 Python 项目启用 semgrep、deptry、trivy 三种扫描工具。

### DIFF
--- a/src/gearbox/agents/shared/scanner.py
+++ b/src/gearbox/agents/shared/scanner.py
@@ -321,7 +321,7 @@ def scan_repository(repo_path: Path) -> RepoScanResult:
     else:
         result.tool_statuses["deptry"] = "skipped"
 
-    if result.project_type in ("typescript", "mixed"):
+    if result.project_type in ("python", "typescript", "mixed"):
         scan_tasks.append(("semgrep", lambda: run_semgrep(repo_path)))
     else:
         result.tool_statuses["semgrep"] = "skipped"

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -304,9 +304,11 @@ class TestToolRunners:
 class TestScanRepositoryOrchestration:
     """scan_repository 的编排逻辑：根据项目类型选择正确的工具组合"""
 
-    def test_python_runs_deptry_and_trivy(self, tmp_path: Path) -> None:
+    def test_python_runs_deptry_trivy_and_semgrep(self, tmp_path: Path) -> None:
+        """Python 项目应启用 deptry、trivy 和 semgrep 扫描（Issue #17）"""
         deptry_issues = [{"type": "x"}]
         trivy_vulns = [{"VulnerabilityID": "V-1"}]
+        semgrep_finds = [{"id": "S-1", "message": "hardcoded secret"}]
 
         with (
             patch(
@@ -318,14 +320,19 @@ class TestScanRepositoryOrchestration:
                 "gearbox.agents.shared.scanner.run_deptry", return_value=(deptry_issues, "issues=1")
             ),
             patch("gearbox.agents.shared.scanner.run_trivy", return_value=(trivy_vulns, "ok")),
+            patch(
+                "gearbox.agents.shared.scanner.run_semgrep",
+                return_value=(semgrep_finds, "ok"),
+            ),
         ):
             actual = scan_repository(tmp_path)
 
         assert actual.deptry_scanned is True
         assert actual.trivy_scanned is True
+        assert actual.semgrep_scanned is True
         assert actual.tool_statuses["deptry"] == "issues=1"
         assert actual.tool_statuses["trivy"] == "ok"
-        assert actual.tool_statuses.get("semgrep") == "skipped"
+        assert actual.tool_statuses["semgrep"] == "ok"
 
     def test_go_runs_govulncheck_and_trivy(self, tmp_path: Path) -> None:
         govuln_vulns = [{"id": "G-1"}]


### PR DESCRIPTION
## Summary

扩展 semgrep 扫描范围至纯 Python 项目，修复 Issue #17 安全盲区。将 scan_repository 中 semgrep 的项目类型条件从 ("typescript", "mixed") 扩展为 ("python", "typescript", "mixed")，使 Python 项目也能获得 OWASP Top 10、SQL 注入、命令注入等安全规则及代码质量规则的覆盖。同步更新测试用例验证 Python 项目启用 semgrep、deptry、trivy 三种扫描工具。

Closes #17