### PR TITLE
feat(#35): Fix _fallback_file_counts() memory exhaustion risk for large repositories (Issue #35). Changes: (1) Added 10 MB file size threshold — files exceeding it are skipped entirely to prevent OOM. (2) Replaced `path.read_text().splitlines()` (which loads full file content into memory) with streaming line-by-line iteration via `open()` + `for` loop, keeping memory usage O(1) per file. (3) Expanded excluded directories list with 6 additional common large/generated dirs: .next, coverage, .tox, .cache, htmlcov, storybook-static. All 301 tests pass, ruff/mypy/format checks clean.

### DIFF
--- a/src/gearbox/agents/shared/scanner.py
+++ b/src/gearbox/agents/shared/scanner.py
@@ -111,6 +111,9 @@ def detect_project_type(repo_path: Path) -> tuple[str, str, bool, bool]:
 
 
 def _fallback_file_counts(repo_path: Path) -> tuple[int, int]:
+    # Maximum file size to read (10 MB); larger files are skipped to prevent OOM.
+    _max_file_bytes = 10 * 1024 * 1024
+
     excluded_dirs = {
         ".git",
         "__pycache__",
@@ -121,6 +124,13 @@ def _fallback_file_counts(repo_path: Path) -> tuple[int, int]:
         ".venv",
         ".mypy_cache",
         ".ruff_cache",
+        # Additional large / generated directories (Issue #35)
+        ".next",
+        "coverage",
+        ".tox",
+        ".cache",
+        "htmlcov",
+        "storybook-static",
     }
     total_files = 0
     total_lines = 0
@@ -130,11 +140,22 @@ def _fallback_file_counts(repo_path: Path) -> tuple[int, int]:
             continue
         if any(part in excluded_dirs for part in path.parts):
             continue
+        # Skip files exceeding size threshold to avoid OOM on large repos
+        try:
+            if path.stat().st_size > _max_file_bytes:
+                continue
+        except OSError:
+            continue
         total_files += 1
         try:
-            total_lines += len(path.read_text(encoding="utf-8", errors="ignore").splitlines())
+            # Count lines by iterating (streaming) — never loads full file into memory
+            nlines = 0
+            with open(path, "r", encoding="utf-8", errors="ignore") as f:
+                for _ in f:
+                    nlines += 1
+            total_lines += nlines
         except Exception:
-            continue
+            pass
 
     return total_files, total_lines
 

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -506,3 +506,37 @@ class TestFallbackFileCounts:
 
         files, lines = _fallback_file_counts(tmp_path)
         assert files == 1  # only real.py, .git and __pycache__ excluded
+
+    def test_skips_files_over_size_threshold(self, tmp_path: Path) -> None:
+        """Files larger than 10 MB should be skipped to prevent OOM (Issue #35)."""
+        (tmp_path / "small.py").write_text("x = 1\n", encoding="utf-8")
+        # Create a file > 10 MB without reading it all into memory at once
+        large = tmp_path / "huge.bin"
+        with open(large, "wb") as f:
+            f.write(b"x" * (10 * 1024 * 1024 + 1))  # 10 MB + 1 byte
+
+        files, lines = _fallback_file_counts(tmp_path)
+        assert files == 1  # only small.py counted
+        assert lines == 1
+
+    def test_excludes_additional_large_dirs(self, tmp_path: Path) -> None:
+        """Common large output dirs should be excluded (Issue #35)."""
+        extra_dirs = [".next", "coverage", ".tox", ".cache", "htmlcov", "storybook-static"]
+        for d in extra_dirs:
+            (tmp_path / d).mkdir()
+            (tmp_path / d / "big.txt").write_text("data\n", encoding="utf-8")
+        (tmp_path / "real.py").write_text("# ok\n", encoding="utf-8")
+
+        files, lines = _fallback_file_counts(tmp_path)
+        assert files == 1
+        assert lines == 1
+
+    def test_does_not_read_full_content_for_line_count(self, tmp_path: Path) -> None:
+        """Line counting should not require loading entire file into memory."""
+        # Write a moderately sized file
+        content = "\n".join([f"line {i}" for i in range(500)])
+        (tmp_path / "data.py").write_text(content, encoding="utf-8")
+
+        files, lines = _fallback_file_counts(tmp_path)
+        assert files == 1
+        assert lines == 500


### PR DESCRIPTION
## Summary

Fix _fallback_file_counts() memory exhaustion risk for large repositories (Issue #35). Changes: (1) Added 10 MB file size threshold — files exceeding it are skipped entirely to prevent OOM. (2) Replaced `path.read_text().splitlines()` (which loads full file content into memory) with streaming line-by-line iteration via `open()` + `for` loop, keeping memory usage O(1) per file. (3) Expanded excluded directories list with 6 additional common large/generated dirs: .next, coverage, .tox, .cache, htmlcov, storybook-static. All 301 tests pass, ruff/mypy/format checks clean.

Closes #35