### PR TITLE
feat(#36): Implement hard token/cost budget ceiling for all agents to prevent cost runaway in abnormal scenarios (Issue #36). Added: (1) `CostBudgetExceededError` exception and `query_with_budget()` async generator wrapper in runtime.py that monitors `total_cost_usd` per message and raises when exceeded; (2) Cost threshold alerts in `SdkEventLogger` — emits GitHub Actions `::warning::` when single-run cost exceeds $2.00 (configurable); (3) Structured output timeout warning for Implement Agent — logs a budget-warning after half of max_turns with no structured output; (4) Integrated `query_with_budget` into all 6 agents (audit, implement, review, backlog, fix, evaluator) with sensible per-agent defaults: audit=$5.0, implement=$15.0, review=$3.0, backlog=$3.0, fix=$5.0, evaluator=$2.0. All 309 tests pass, ruff + mypy clean.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -179,6 +179,7 @@ async def run_audit(
     *,
     model: str | None = None,
     max_turns: int = 20,
+    max_cost_usd: float | None = 5.0,
     system_prompt: str | None = None,
     enable_prescan: bool = True,
 ) -> AuditResult:
@@ -191,19 +192,17 @@ async def run_audit(
         output_dir: 输出目录
         model: 使用的模型
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
         system_prompt: 自定义 System Prompt（可选，默认使用内置）
         enable_prescan: 是否启用预扫描（默认 True）
 
     Returns:
         AuditResult 结构
     """
-    from claude_agent_sdk import (
-        ClaudeAgentOptions,
-        query,
-    )
+    from claude_agent_sdk import ClaudeAgentOptions
 
     from gearbox.agents.schemas import output_format_schema, parse_with_model
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
     from gearbox.agents.shared.scanner import (
         format_scan_summary,
         scan_repository,
@@ -326,7 +325,11 @@ async def run_audit(
         total_cost: float | None = None
 
         try:
-            async for message in query(prompt=prompt, options=options):
+            async for message in query_with_budget(
+                prompt=prompt,
+                options=options,
+                max_cost_usd=max_cost_usd,
+            ):
                 sdk_logger.handle_message(message, echo_assistant_text=False)
                 total_cost = getattr(message, "total_cost_usd", total_cost)
                 if structured is None:

--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -157,6 +157,7 @@ async def run_backlog_item(
     *,
     model: str = "claude-sonnet-4-6",
     max_turns: int = 15,
+    max_cost_usd: float | None = 3.0,
 ) -> BacklogItemResult:
     """
     执行 Issue 分类。
@@ -166,18 +167,19 @@ async def run_backlog_item(
         issue_number: Issue 编号
         model: 使用的模型
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
 
     Returns:
         BacklogItemResult 结构
     """
     import tempfile
 
-    from claude_agent_sdk import ClaudeAgentOptions, query
+    from claude_agent_sdk import ClaudeAgentOptions
 
     from gearbox.agents.schemas import output_format_schema, parse_with_model
     from gearbox.agents.shared import clone_repository
     from gearbox.agents.shared.prompt_helpers import format_issues_summary
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
     from gearbox.core.gh import list_open_issues
 
     issue = _gh_issue_view(repo, issue_number)
@@ -233,7 +235,11 @@ async def run_backlog_item(
     structured: BacklogItemResult | None = None
 
     try:
-        async for message in query(prompt=prompt, options=options):
+        async for message in query_with_budget(
+            prompt=prompt,
+            options=options,
+            max_cost_usd=max_cost_usd,
+        ):
             sdk_logger.handle_message(message, echo_assistant_text=False)
             if structured is None:
                 parsed = parse_with_model(message, BacklogItemResult)

--- a/src/gearbox/agents/evaluator.py
+++ b/src/gearbox/agents/evaluator.py
@@ -97,6 +97,7 @@ async def run_evaluator(
     *,
     model: str = "claude-sonnet-4-6",
     max_turns: int = DEFAULT_EVALUATOR_MAX_TURNS,
+    max_cost_usd: float | None = 2.0,
 ) -> EvaluationResult:
     """
     运行评估器。
@@ -107,17 +108,15 @@ async def run_evaluator(
         result_names: 可选的名称列表
         model: 使用的模型
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
 
     Returns:
         EvaluationResult
     """
-    from claude_agent_sdk import (
-        ClaudeAgentOptions,
-        query,
-    )
+    from claude_agent_sdk import ClaudeAgentOptions
 
     from gearbox.agents.schemas import output_format_schema, parse_with_model
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
     from gearbox.config import get_anthropic_model
 
     model = model or get_anthropic_model()
@@ -143,7 +142,11 @@ async def run_evaluator(
     structured: EvaluationResult | None = None
 
     try:
-        async for message in query(prompt=prompt, options=options):
+        async for message in query_with_budget(
+            prompt=prompt,
+            options=options,
+            max_cost_usd=max_cost_usd,
+        ):
             sdk_logger.handle_message(message, echo_assistant_text=False)
             if structured is None:
                 parsed = parse_with_model(message, EvaluationResult)

--- a/src/gearbox/agents/fix.py
+++ b/src/gearbox/agents/fix.py
@@ -96,6 +96,7 @@ async def run_fix(
     *,
     model: str = "claude-sonnet-4-6",
     max_turns: int = DEFAULT_FIX_MAX_TURNS,
+    max_cost_usd: float | None = 5.0,
 ) -> FixResult:
     """
     执行 Fix Agent — 根据 Review 反馈修补 PR。
@@ -105,13 +106,14 @@ async def run_fix(
         pr_number: PR 编号
         model: 使用的模型
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
 
     Returns:
         FixResult 结构
     """
-    from claude_agent_sdk import ClaudeAgentOptions, query
+    from claude_agent_sdk import ClaudeAgentOptions
 
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
     from gearbox.config import get_anthropic_model
 
     resolved_model = model or get_anthropic_model()
@@ -144,7 +146,11 @@ async def run_fix(
     structured: FixResult | None = None
 
     try:
-        async for message in query(prompt=prompt, options=options):
+        async for message in query_with_budget(
+            prompt=prompt,
+            options=options,
+            max_cost_usd=max_cost_usd,
+        ):
             sdk_logger.handle_message(message, echo_assistant_text=False)
             if structured is None:
                 parsed = parse_with_model(message, FixResult)

--- a/src/gearbox/agents/implement.py
+++ b/src/gearbox/agents/implement.py
@@ -115,6 +115,7 @@ async def run_implement(
     run_id: int = 0,
     base_branch: str = "main",
     max_turns: int = 80,
+    max_cost_usd: float | None = 15.0,
 ) -> ImplementResult:
     """
     执行 Issue 实现。
@@ -125,16 +126,17 @@ async def run_implement(
         model: 使用的模型
         base_branch: PR 目标分支
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
 
     Returns:
         ImplementResult 结构
     """
     from pathlib import Path
 
-    from claude_agent_sdk import ClaudeAgentOptions, query
+    from claude_agent_sdk import ClaudeAgentOptions
 
     from gearbox.agents.schemas import output_format_schema, parse_with_model
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
 
     project_root = Path.cwd()
     issue = _gh_issue_view(repo, issue_number)
@@ -173,15 +175,35 @@ async def run_implement(
     )
 
     structured: ImplementResult | None = None
+    _max_turns_without_output = max_turns // 2  # e.g. 40 turns for max_turns=80
 
     try:
-        async for message in query(prompt=prompt, options=options):
+        turn_count = 0
+        async for message in query_with_budget(
+            prompt=prompt,
+            options=options,
+            max_cost_usd=max_cost_usd,
+        ):
             sdk_logger.handle_message(message, echo_assistant_text=False)
             if structured is None:
                 parsed = parse_with_model(message, ImplementResult)
                 if parsed is not None:
                     structured = parsed
                     break
+
+            # Track turns for structured output timeout fallback
+            if hasattr(message, "num_turns"):
+                turn_count = message.num_turns
+                if (
+                    turn_count > 0
+                    and turn_count % _max_turns_without_output == 0
+                    and structured is None
+                ):
+                    sdk_logger._log(
+                        "budget-warning",
+                        f"no structured output after {turn_count} turns "
+                        f"(threshold={_max_turns_without_output}), continuing...",
+                    )
     finally:
         sdk_logger.log_completion()
 

--- a/src/gearbox/agents/review.py
+++ b/src/gearbox/agents/review.py
@@ -103,6 +103,7 @@ async def run_review(
     *,
     model: str = "claude-sonnet-4-6",
     max_turns: int = 10,
+    max_cost_usd: float | None = 3.0,
     previous_review_summary: str | None = None,
 ) -> ReviewResult:
     """
@@ -113,6 +114,7 @@ async def run_review(
         pr_number: PR 编号
         model: 使用的模型
         max_turns: 最大对话轮次
+        max_cost_usd: 成本上限（美元），None 表示不限制
         previous_review_summary: 上一次审查的摘要，用于增量审查（可选）
 
     Returns:
@@ -120,10 +122,10 @@ async def run_review(
     """
     from pathlib import Path
 
-    from claude_agent_sdk import ClaudeAgentOptions, query
+    from claude_agent_sdk import ClaudeAgentOptions
 
     from gearbox.agents.schemas import output_format_schema, parse_with_model
-    from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.runtime import prepare_agent_options, query_with_budget
 
     project_root = Path(__file__).resolve().parents[3]
     pr_info = _gh_pr_view(repo, pr_number)
@@ -170,7 +172,11 @@ async def run_review(
     structured: ReviewResult | None = None
 
     try:
-        async for message in query(prompt=prompt, options=options):
+        async for message in query_with_budget(
+            prompt=prompt,
+            options=options,
+            max_cost_usd=max_cost_usd,
+        ):
             sdk_logger.handle_message(message, echo_assistant_text=False)
             if structured is None:
                 parsed = parse_with_model(message, ReviewResult)

--- a/src/gearbox/agents/shared/runtime.py
+++ b/src/gearbox/agents/shared/runtime.py
@@ -18,9 +18,28 @@ from claude_agent_sdk import (
     TaskProgressMessage,
     TaskStartedMessage,
     TextBlock,
+    query,
 )
 
 from gearbox.config import get_anthropic_api_key, get_anthropic_base_url
+
+
+class CostBudgetExceededError(RuntimeError):
+    """Agent 执行成本超过预算上限时抛出。"""
+
+    def __init__(
+        self,
+        message: str = "Cost budget exceeded",
+        *,
+        cost_usd: float | None = None,
+        limit_usd: float | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.cost_usd = cost_usd
+        self.limit_usd = limit_usd
+
+
+_DEFAULT_COST_WARNING_THRESHOLD_USD = 2.0
 
 _HEARTBEAT_INTERVAL_SECONDS = 20.0
 _HEARTBEAT_IDLE_THRESHOLD_SECONDS = 20.0
@@ -132,8 +151,15 @@ def _safe_get(mapping: Any, *path: str) -> Any | None:
 class SdkEventLogger:
     """把 SDK 原生事件转成适合终端和 GitHub Actions 的日志。"""
 
-    def __init__(self, agent_name: str) -> None:
+    def __init__(
+        self,
+        agent_name: str,
+        *,
+        cost_warning_threshold_usd: float = _DEFAULT_COST_WARNING_THRESHOLD_USD,
+    ) -> None:
         self.agent_name = agent_name
+        self.cost_warning_threshold_usd = cost_warning_threshold_usd
+        self._cost_warning_emitted = False
         self._open_task_ids: set[str] = set()
         self._heartbeat_stop = threading.Event()
         self._heartbeat_thread: threading.Thread | None = None
@@ -222,6 +248,19 @@ class SdkEventLogger:
         self.close_open_groups()
         self._stop_heartbeat()
         self._log("done", "agent execution finished")
+
+    def _check_cost_threshold(self, message: ResultMessage) -> None:
+        """当累计成本超过阈值时发出 GitHub Actions ::warning::。"""
+        if (
+            not self._cost_warning_emitted
+            and message.total_cost_usd is not None
+            and message.total_cost_usd >= self.cost_warning_threshold_usd
+        ):
+            self._cost_warning_emitted = True
+            _print_line(
+                f"::warning::[{self.agent_name}] cost threshold exceeded: "
+                f"${message.total_cost_usd:.2f} >= ${self.cost_warning_threshold_usd:.2f}"
+            )
 
     def close_open_groups(self) -> None:
         while self._open_task_ids:
@@ -337,6 +376,7 @@ class SdkEventLogger:
 
         if isinstance(message, ResultMessage):
             self._flush_stream_text()
+            self._check_cost_threshold(message)
             fields = [
                 f"turns={message.num_turns}",
                 f"duration_ms={message.duration_ms}",
@@ -408,3 +448,51 @@ def prepare_agent_options(
         ),
         logger,
     )
+
+
+async def query_with_budget(
+    prompt: str,
+    options: ClaudeAgentOptions,
+    *,
+    max_cost_usd: float | None = None,
+) -> Any:
+    """包装 SDK ``query()``，在应用层强制执行成本预算上限。
+
+    与 :func:`claude_agent_sdk.query` 接口一致——同样是异步生成器，
+    逐条 yield 消息。在每条消息上检查 ``total_cost_usd``，
+    一旦累计成本超过 *max_cost_usd*，立即停止迭代并抛出
+    :class:`CostBudgetExceededError`。
+
+    用法与 ``query()`` 完全兼容，可直接替换::
+
+        # Before
+        async for msg in query(prompt, options): ...
+
+        # After
+        async for msg in query_with_budget(prompt, options, max_cost_usd=5.0): ...
+
+    Args:
+        prompt: Agent 提示词。
+        options: SDK 选项（含 model、max_turns 等）。
+        max_cost_usd: 成本上限（美元）。为 ``None`` 时不做限制。
+
+    Yields:
+        与底层 ``query()`` 相同的消息对象。
+
+    Raises:
+        CostBudgetExceededError: 当累计成本超过 *max_cost_usd* 时。
+    """
+    if max_cost_usd is not None and max_cost_usd <= 0:
+        raise ValueError("max_cost_usd must be positive or None")
+
+    async for message in query(prompt=prompt, options=options):
+        yield message
+
+        if max_cost_usd is not None:
+            cost = getattr(message, "total_cost_usd", None)
+            if isinstance(cost, (int, float)) and cost > max_cost_usd:
+                raise CostBudgetExceededError(
+                    f"Agent cost ${cost:.2f} exceeded budget ${max_cost_usd:.2f}",
+                    cost_usd=float(cost),
+                    limit_usd=max_cost_usd,
+                )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -277,7 +277,7 @@ class TestStructuredOutputParsing:
             return options, FakeLogger()
 
         monkeypatch.setattr(implement, "_gh_issue_view", lambda *args: {"title": "T", "body": "B"})
-        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
         monkeypatch.setattr(
             "gearbox.agents.shared.runtime.prepare_agent_options",
             fake_prepare_agent_options,

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -390,7 +390,7 @@ class TestFixAgent:
             "gearbox.agents.fix._gh_pr_view",
             lambda *a, **k: {"title": "T", "body": "B", "headRefName": "feat/issue-1"},
         )
-        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
         monkeypatch.setattr("gearbox.agents.shared.runtime.prepare_agent_options", fake_prepare)
 
         import asyncio
@@ -434,7 +434,7 @@ class TestFixAgent:
             capture_options(opts)
             return opts, FakeLogger()
 
-        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
         monkeypatch.setattr("gearbox.agents.shared.runtime.prepare_agent_options", fake_prepare)
 
         import asyncio
@@ -474,7 +474,7 @@ class TestFixAgent:
         monkeypatch.setattr(
             "gearbox.agents.fix._gh_pr_view", lambda *a, **k: {"title": "T", "headRefName": "f/i-1"}
         )
-        monkeypatch.setattr("claude_agent_sdk.query", fake_query_no_structured)
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query_no_structured)
         monkeypatch.setattr("gearbox.agents.shared.runtime.prepare_agent_options", fake_prepare)
 
         import asyncio

--- a/tests/test_sdk_logging.py
+++ b/tests/test_sdk_logging.py
@@ -1,10 +1,19 @@
-"""测试 Claude Agent SDK 日志适配。"""
+"""测试 Claude Agent SDK 日志适配和预算控制。"""
 
 import os
 
-from claude_agent_sdk import ClaudeAgentOptions, StreamEvent
+from claude_agent_sdk import (
+    ClaudeAgentOptions,
+    ResultMessage,
+    StreamEvent,
+)
 
-from gearbox.agents.shared.runtime import SdkEventLogger, prepare_agent_options
+from gearbox.agents.shared.runtime import (
+    CostBudgetExceededError,
+    SdkEventLogger,
+    prepare_agent_options,
+    query_with_budget,
+)
 
 
 class TestPrepareSdkOptions:
@@ -143,3 +152,231 @@ class TestSdkEventLogger:
             stage == "tool-use" and "tool=Bash, command=rg -n" in message
             for _, stage, message in entries
         )
+
+
+class TestCostBudgetExceededError:
+    """CostBudgetExceededError 异常行为测试。"""
+
+    def test_is_exception_subclass(self) -> None:
+        assert issubclass(CostBudgetExceededError, RuntimeError)
+
+    def test_preserves_message_and_cost(self) -> None:
+        err = CostBudgetExceededError("budget hit", cost_usd=3.50, limit_usd=2.00)
+        assert "budget hit" in str(err)
+        assert err.cost_usd == 3.50
+        assert err.limit_usd == 2.00
+
+    def test_default_values(self) -> None:
+        err = CostBudgetExceededError("test")
+        assert err.cost_usd is None
+        assert err.limit_usd is None
+
+
+class TestQueryWithBudget:
+    """query_with_budget 预算控制包装器测试。"""
+
+    @staticmethod
+    def _make_result_msg(cost: float, turns: int) -> ResultMessage:
+        return ResultMessage(
+            subtype="result",
+            duration_ms=1000,
+            duration_api_ms=800,
+            is_error=False,
+            num_turns=turns,
+            session_id="s1",
+            total_cost_usd=cost,
+        )
+
+    def test_passes_all_messages_when_under_budget(self, monkeypatch) -> None:
+        """预算未超限时，所有消息正常透传。"""
+        messages = [
+            self._make_result_msg(0.30, 1),
+            self._make_result_msg(0.50, 2),
+        ]
+
+        async def fake_query(*args, **kwargs):
+            del args, kwargs
+            for msg in messages:
+                yield msg
+
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
+
+        collected = []
+
+        async def _collect():
+            async for msg in query_with_budget(
+                prompt="test",
+                options=ClaudeAgentOptions(model="test", max_turns=10),
+                max_cost_usd=2.0,
+            ):
+                collected.append(msg)
+
+        import asyncio
+
+        asyncio.run(_collect())
+
+        assert len(collected) == 2
+
+    def test_stops_when_cost_exceeds_limit(self, monkeypatch) -> None:
+        """成本超过 max_cost_usd 时提前终止迭代并抛出异常。"""
+        messages = [
+            self._make_result_msg(0.50, 1),
+            self._make_result_msg(1.00, 2),
+            self._make_result_msg(3.0, 3),  # 超过 $2.00 预算
+            self._make_result_msg(4.0, 4),  # 不应被消费
+        ]
+
+        async def fake_query(*args, **kwargs):
+            del args, kwargs
+            for msg in messages:
+                yield msg
+
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
+
+        collected: list[object] = []
+        raised = False
+
+        async def _run():
+            nonlocal raised
+            try:
+                async for msg in query_with_budget(
+                    prompt="test",
+                    options=ClaudeAgentOptions(model="test", max_turns=10),
+                    max_cost_usd=2.0,
+                ):
+                    collected.append(msg)
+            except CostBudgetExceededError:
+                raised = True
+
+        import asyncio
+
+        asyncio.run(_run())
+
+        # 应该收到前两条消息 + 触发超限的 result 消息（用于检测）
+        assert len(collected) == 3
+        assert raised
+
+    def test_no_budget_constraint_when_max_cost_is_none(self, monkeypatch) -> None:
+        """max_cost_usd=None 时不做任何预算检查。"""
+        messages = [self._make_result_msg(999.99, 1)]
+
+        async def fake_query(*args, **kwargs):
+            del args, kwargs
+            for msg in messages:
+                yield msg
+
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
+
+        collected: list[object] = []
+
+        async def _collect():
+            async for msg in query_with_budget(
+                prompt="test",
+                options=ClaudeAgentOptions(model="test", max_turns=10),
+                max_cost_usd=None,
+            ):
+                collected.append(msg)
+
+        import asyncio
+
+        asyncio.run(_collect())
+
+        assert len(collected) == 1
+
+    def test_raises_with_correct_cost_details(self, monkeypatch) -> None:
+        """异常携带正确的 cost/limit 信息。"""
+        messages = [self._make_result_msg(5.0, 10)]
+
+        async def fake_query(*args, **kwargs):
+            del args, kwargs
+            for msg in messages:
+                yield msg
+
+        monkeypatch.setattr("gearbox.agents.shared.runtime.query", fake_query)
+
+        caught: CostBudgetExceededError | None = None
+
+        async def _run():
+            nonlocal caught
+            try:
+                async for _msg in query_with_budget(
+                    prompt="test",
+                    options=ClaudeAgentOptions(model="test", max_turns=10),
+                    max_cost_usd=2.0,
+                ):
+                    pass
+            except CostBudgetExceededError as e:
+                caught = e
+
+        import asyncio
+
+        asyncio.run(_run())
+
+        assert caught is not None
+        assert caught.cost_usd == 5.0
+        assert caught.limit_usd == 2.0
+
+
+class TestSdkEventLoggerCostAlert:
+    """SdkEventLogger 成本阈值告警测试。"""
+
+    def test_emits_warning_when_cost_exceeds_threshold(self, monkeypatch) -> None:
+        """cost 超过阈值时输出 ::warning:: 日志。"""
+        printed: list[str] = []
+
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *a, **kw: printed.append(" ".join(str(x) for x in a)),
+        )
+
+        logger = SdkEventLogger("audit", cost_warning_threshold_usd=2.0)
+        logger.handle_message(
+            ResultMessage(
+                subtype="result",
+                duration_ms=5000,
+                duration_api_ms=4000,
+                is_error=False,
+                num_turns=15,
+                session_id="s1",
+                total_cost_usd=3.50,
+            )
+        )
+
+        warnings = [p for p in printed if "::warning::" in p]
+        assert len(warnings) >= 1
+        assert "3.50" in warnings[0]
+
+    def test_no_warning_when_cost_below_threshold(self, monkeypatch) -> None:
+        """cost 未超过阈值时不输出 warning。"""
+        printed: list[str] = []
+
+        monkeypatch.setattr(
+            "builtins.print",
+            lambda *a, **kw: printed.append(" ".join(str(x) for x in a)),
+        )
+
+        logger = SdkEventLogger("audit", cost_warning_threshold_usd=2.0)
+        logger.handle_message(
+            ResultMessage(
+                subtype="result",
+                duration_ms=1000,
+                duration_api_ms=800,
+                is_error=False,
+                num_turns=3,
+                session_id="s1",
+                total_cost_usd=0.80,
+            )
+        )
+
+        warnings = [p for p in printed if "::warning::" in p]
+        assert len(warnings) == 0
+
+    def test_default_threshold_is_2_dollars(self) -> None:
+        """默认阈值为 $2.00。"""
+        logger = SdkEventLogger("audit")
+        assert logger.cost_warning_threshold_usd == 2.0
+
+    def test_custom_threshold_via_init(self) -> None:
+        """可通过构造参数自定义阈值。"""
+        logger = SdkEventLogger("audit", cost_warning_threshold_usd=5.0)
+        assert logger.cost_warning_threshold_usd == 5.0


### PR DESCRIPTION
## Summary

Implement hard token/cost budget ceiling for all agents to prevent cost runaway in abnormal scenarios (Issue #36). Added: (1) `CostBudgetExceededError` exception and `query_with_budget()` async generator wrapper in runtime.py that monitors `total_cost_usd` per message and raises when exceeded; (2) Cost threshold alerts in `SdkEventLogger` — emits GitHub Actions `::warning::` when single-run cost exceeds $2.00 (configurable); (3) Structured output timeout warning for Implement Agent — logs a budget-warning after half of max_turns with no structured output; (4) Integrated `query_with_budget` into all 6 agents (audit, implement, review, backlog, fix, evaluator) with sensible per-agent defaults: audit=$5.0, implement=$15.0, review=$3.0, backlog=$3.0, fix=$5.0, evaluator=$2.0. All 309 tests pass, ruff + mypy clean.

Closes #36