### PR TITLE
feat(#38): Fix semgrep duplicate findings (Issue #38): Added `_semgrep_finding_key()` deduplication helper using `(check_id, path, line, message)` tuple as unique key, and modified `run_semgrep()` to skip already-seen findings when merging results from `auto` and `p/security` configs. Updated existing test assertion from `len==2` to `len==1` and added new `test_semgrep_deduplicates_overlapping_findings` test covering partial overlap scenario. All 299 tests pass, lint/format/mypy clean.

### DIFF
--- a/src/gearbox/agents/shared/scanner.py
+++ b/src/gearbox/agents/shared/scanner.py
@@ -161,9 +161,21 @@ def run_cloc(repo_path: Path) -> tuple[dict[str, Any], str]:
     return {}, detail
 
 
+def _semgrep_finding_key(f: dict[str, Any]) -> tuple:
+    """生成 finding 的去重键：(check_id, path, line, message)"""
+    start = f.get("start", {})
+    return (
+        f.get("check_id", ""),
+        f.get("path", ""),
+        start.get("line", 0) if isinstance(start, dict) else 0,
+        f.get("message", ""),
+    )
+
+
 def run_semgrep(repo_path: Path) -> tuple[list[dict[str, Any]], str]:
     """执行 semgrep 扫描"""
     findings: list[dict[str, Any]] = []
+    seen: set[tuple] = set()
     had_success = False
     last_error = "command_failed"
     for config in ["auto", "p/security"]:
@@ -176,7 +188,11 @@ def run_semgrep(repo_path: Path) -> tuple[list[dict[str, Any]], str]:
             had_success = True
             try:
                 data = json.loads(stdout)
-                findings.extend(data.get("results", []))  # type: ignore[arg-type]
+                for result in data.get("results", []):  # type: ignore[arg-type]
+                    key = _semgrep_finding_key(result)
+                    if key not in seen:
+                        seen.add(key)
+                        findings.append(result)
             except json.JSONDecodeError:
                 return findings, "parse_failed"
         else:

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -211,9 +211,47 @@ class TestToolRunners:
             findings, status = run_semgrep(tmp_path)
 
         assert status == "ok"
-        # semgrep 运行两个配置（auto + p/security），每个都返回相同结果
-        assert len(findings) == 2
+        # auto 和 p/security 返回相同 finding 时应去重，只保留一份
+        assert len(findings) == 1
         assert findings[0]["id"] == "1"
+
+    def test_semgrep_deduplicates_overlapping_findings(self, tmp_path: Path) -> None:
+        """两个配置返回重叠结果时，去重后只保留独立 finding（Issue #38）"""
+        finding_a = {
+            "id": "A",
+            "check_id": "X",
+            "path": "foo.py",
+            "start": {"line": 10},
+            "message": "dup",
+        }
+        finding_b = {
+            "id": "B",
+            "check_id": "Y",
+            "path": "bar.py",
+            "start": {"line": 5},
+            "message": "unique",
+        }
+
+        call_count = 0
+
+        def _fake_multi(cmd, cwd, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # auto config returns both A and B
+                return 0, json.dumps({"results": [finding_a, finding_b]}), ""
+            else:
+                # p/security config returns only A (subset)
+                return 0, json.dumps({"results": [finding_a]}), ""
+
+        with patch("gearbox.agents.shared.scanner._run_command", _fake_multi):
+            findings, status = run_semgrep(tmp_path)
+
+        assert status == "ok"
+        # A 出现在两次扫描中但只应计入一次，B 只出现一次 → 共 2 条
+        assert len(findings) == 2
+        ids = {f["id"] for f in findings}
+        assert ids == {"A", "B"}
 
     def test_semgrep_no_findings_but_succeeded(self, tmp_path: Path) -> None:
         fake = self._fake_run(0, json.dumps({"results": []}))


### PR DESCRIPTION
## Summary

Fix semgrep duplicate findings (Issue #38): Added `_semgrep_finding_key()` deduplication helper using `(check_id, path, line, message)` tuple as unique key, and modified `run_semgrep()` to skip already-seen findings when merging results from `auto` and `p/security` configs. Updated existing test assertion from `len==2` to `len==1` and added new `test_semgrep_deduplicates_overlapping_findings` test covering partial overlap scenario. All 299 tests pass, lint/format/mypy clean.

Closes #38