### PR TITLE
feat(#40): Fix Issue #40: Restrict config file permissions to prevent plaintext credential leakage. Changes: (1) `save_config()` now calls `os.chmod(config_file, 0o600)` after writing to restrict file to owner-only read/write; (2) `ensure_config_dir()` now sets directory permissions to 0o700 to prevent directory traversal attacks; (3) Added `_warn_if_insecure_permissions()` helper that emits a `UserWarning` when `load_config()` detects overly permissive file permissions (group/other read/write bits set). All changes follow TDD with 4 new tests covering file 0o600, directory 0o700, no world-readable bits, and permission warning on load.

### DIFF
--- a/src/gearbox/config/settings.py
+++ b/src/gearbox/config/settings.py
@@ -1,6 +1,8 @@
 """配置管理 - 读写用户配置"""
 
 import os
+import stat
+import warnings
 from pathlib import Path
 from typing import Any, cast
 
@@ -26,8 +28,13 @@ def _config_file() -> Path:
 
 
 def ensure_config_dir() -> None:
-    """确保配置目录存在"""
-    _config_dir().mkdir(parents=True, exist_ok=True)
+    """确保配置目录存在，并限制目录权限为仅 owner 可访问（0o700）"""
+    config_dir = _config_dir()
+    config_dir.mkdir(parents=True, exist_ok=True)
+    # 限制配置目录权限，防止其他用户读取其中的敏感文件
+    current_mode = stat.S_IMODE(config_dir.stat().st_mode)
+    if current_mode != 0o700:
+        config_dir.chmod(0o700)
 
 
 def get_config_path() -> Path:
@@ -36,10 +43,13 @@ def get_config_path() -> Path:
 
 
 def load_config() -> dict[str, Any]:
-    """加载配置文件"""
+    """加载配置文件，并在权限过宽时发出警告"""
     config_file = get_config_path()
     if not config_file.exists():
         return {}
+
+    # 检查文件权限是否安全（仅 owner 可读写）
+    _warn_if_insecure_permissions(config_file)
 
     try:
         import tomli
@@ -52,12 +62,32 @@ def load_config() -> dict[str, Any]:
         return {}
 
 
+def _warn_if_insecure_permissions(config_file: Path) -> None:
+    """如果配置文件权限过宽，发出 UserWarning 警告"""
+    try:
+        mode = stat.S_IMODE(config_file.stat().st_mode)
+        # 检查组或其他用户是否有任何读/写权限
+        if mode & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH):
+            warnings.warn(
+                f"Config file {config_file} has insecure permissions {oct(mode)}. "
+                "Recommended: 0o600 (owner read/write only). "
+                "Run: chmod 600 " + str(config_file),
+                UserWarning,
+                stacklevel=3,
+            )
+    except OSError:
+        pass  # 无法读取权限时静默跳过
+
+
 def save_config(config: dict[str, Any]) -> None:
-    """保存配置文件"""
+    """保存配置文件，并限制文件权限为仅 owner 可读写（0o600）"""
     ensure_config_dir()
 
-    with open(get_config_path(), "wb") as f:
+    config_file = get_config_path()
+    with open(config_file, "wb") as f:
         tomli_w.dump(config, f)
+    # 限制文件权限：仅 owner 可读写，防止多用户环境下凭证泄露
+    os.chmod(config_file, 0o600)
 
 
 def get_github_token() -> str | None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 """测试 config 模块"""
 
 import os
+import stat
+import warnings
 from pathlib import Path
 
 from gearbox.config import (
@@ -176,3 +178,69 @@ class TestAgentDefaults:
         assert "implement" in AGENT_DEFAULTS["max_turns"]
         assert "audit" in AGENT_DEFAULTS["max_turns"]
         assert AGENT_DEFAULTS["max_turns"]["implement"] == 80
+
+
+class TestConfigFilePermissions:
+    """测试配置文件权限限制 (Issue #40)"""
+
+    def test_save_config_sets_file_permissions_0o600(self, temp_home: Path) -> None:
+        """save_config 写入后应将配置文件权限设为 0o600（仅 owner 可读写）"""
+        os.environ["XDG_CONFIG_HOME"] = str(temp_home)
+
+        save_config({"anthropic_api_key": "sk-test-key", "github_token": "ghp_test"})
+
+        config_file = get_config_path()
+        mode = stat.S_IMODE(config_file.stat().st_mode)
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_save_config_restricts_directory_permissions(self, temp_home: Path) -> None:
+        """save_config 应限制配置目录权限为 0o700"""
+        os.environ["XDG_CONFIG_HOME"] = str(temp_home)
+
+        save_config({"test_key": "test_value"})
+
+        config_dir = get_config_path().parent
+        dir_mode = stat.S_IMODE(config_dir.stat().st_mode)
+        # 目录应仅允许 owner 访问
+        assert dir_mode == 0o700, f"Expected directory 0o700, got {oct(dir_mode)}"
+
+    def test_save_config_with_sensitive_data_is_not_world_readable(
+        self,
+        temp_home: Path,
+    ) -> None:
+        """包含敏感数据的配置文件不应被其他用户读取"""
+        os.environ["XDG_CONFIG_HOME"] = str(temp_home)
+
+        save_config(
+            {
+                "anthropic_api_key": "sk-secret-12345",
+                "github_token": "ghp_secret_token",
+            }
+        )
+
+        config_file = get_config_path()
+        mode = stat.S_IMODE(config_file.stat().st_mode)
+        # 确保组和其他用户无任何权限
+        assert mode & stat.S_IRGRP == 0, "Group should not have read permission"
+        assert mode & stat.S_IWGRP == 0, "Group should not have write permission"
+        assert mode & stat.S_IROTH == 0, "Others should not have read permission"
+        assert mode & stat.S_IWOTH == 0, "Others should not have write permission"
+
+    def test_load_config_warns_on_insecure_permissions(self, temp_home: Path) -> None:
+        """load_config 在文件权限过宽时应发出警告"""
+        os.environ["XDG_CONFIG_HOME"] = str(temp_home)
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+
+        # 手动创建一个权限过宽的配置文件
+        config_file = config_dir / "config.toml"
+        config_file.write_text('key = "value"', encoding="utf-8")
+        config_file.chmod(0o644)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            load_config()
+            warning_messages = [str(x.message) for x in w]
+            assert any("permission" in msg.lower() or "权限" in msg for msg in warning_messages), (
+                f"Expected a permission warning but got: {[str(x.message) for x in w]}"
+            )


### PR DESCRIPTION
## Summary

Fix Issue #40: Restrict config file permissions to prevent plaintext credential leakage. Changes: (1) `save_config()` now calls `os.chmod(config_file, 0o600)` after writing to restrict file to owner-only read/write; (2) `ensure_config_dir()` now sets directory permissions to 0o700 to prevent directory traversal attacks; (3) Added `_warn_if_insecure_permissions()` helper that emits a `UserWarning` when `load_config()` detects overly permissive file permissions (group/other read/write bits set). All changes follow TDD with 4 new tests covering file 0o600, directory 0o700, no world-readable bits, and permission warning on load.

Closes #40