### PR TITLE
feat(#51): Fix path traversal vulnerability in benchmark cache file paths (Issue #51). Added `_sanitize_repo_name()` to validate repo identifiers (whitelist `[a-zA-Z0-9_-/]`, reject `..`, `.`, `//`, and special chars), `_benchmark_cache_path()` with `resolve().is_relative_to()` boundary assertion, and updated both `_get_cached_benchmarks()` / `_cache_benchmarks()` to silently reject malicious inputs. Added 7 tests covering sanitization acceptance/rejection, write blocking, read blocking, and boundary verification.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -22,6 +22,49 @@ OUTPUT_FILES = ("profile.json", "comparison.md", "issues.json")
 # Benchmark 缓存
 _BENCHMARK_CACHE_DIR = Path.home() / ".cache" / "gearbox" / "benchmarks"
 
+# Allowed characters in repo identifiers: alphanumeric, hyphen, underscore, forward slash
+_VALID_REPO_CHARS = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_/")
+_INVALID_REPO_PATTERNS = ("..", "//")
+
+
+def _sanitize_repo_name(repo: str) -> str:
+    """Validate and sanitize a repo identifier for safe use as a cache filename.
+
+    Only ``[a-zA-Z0-9_-/]`` characters are accepted.  Sequences that could
+    enable path traversal (``..``, ``//``) or a bare ``.`` are rejected.
+
+    Raises:
+        ValueError: If *repo* contains disallowed characters or patterns.
+    """
+    if not repo:
+        raise ValueError("repo must not be empty")
+
+    if any(p in repo for p in _INVALID_REPO_PATTERNS):
+        raise ValueError(f"invalid repo: {repo!r} contains path-traversal pattern")
+
+    # Reject standalone dot (could be used to create hidden files)
+    stripped = repo.strip()
+    if stripped == ".":
+        raise ValueError(f"invalid repo: {repo!r}")
+
+    invalid_chars = set(stripped) - _VALID_REPO_CHARS
+    if invalid_chars:
+        raise ValueError(
+            f"invalid repo: {repo!r} contains disallowed characters: {sorted(invalid_chars)!r}"
+        )
+
+    return stripped
+
+
+def _benchmark_cache_path(repo: str) -> Path:
+    """Return the cache file path for *repo*, with boundary assertion."""
+    sanitized = _sanitize_repo_name(repo)
+    cache_file = _BENCHMARK_CACHE_DIR / f"{sanitized.replace('/', '_')}.json"
+    resolved = cache_file.resolve()
+    if not resolved.is_relative_to(_BENCHMARK_CACHE_DIR.resolve()):
+        raise ValueError(f"resolved cache path {resolved} escapes {_BENCHMARK_CACHE_DIR}")
+    return cache_file
+
 
 def _write_audit_outputs(result: AuditResult, output_dir: Path) -> None:
     """由宿主进程统一写出 audit 产物文件。"""
@@ -58,7 +101,11 @@ def _write_audit_outputs(result: AuditResult, output_dir: Path) -> None:
 
 def _get_cached_benchmarks(repo: str, language: str | None = None) -> list[str] | None:
     """获取缓存的对标仓库列表"""
-    cache_file = _BENCHMARK_CACHE_DIR / f"{repo.replace('/', '_')}.json"
+    try:
+        cache_file = _benchmark_cache_path(repo)
+    except ValueError:
+        # Reject path-traversal repo names silently
+        return None
     if cache_file.exists():
         try:
             data = json.loads(cache_file.read_text())
@@ -72,7 +119,11 @@ def _get_cached_benchmarks(repo: str, language: str | None = None) -> list[str] 
 
 def _cache_benchmarks(repo: str, benchmarks: list[str]) -> None:
     """缓存对标仓库列表"""
-    cache_file = _BENCHMARK_CACHE_DIR / f"{repo.replace('/', '_')}.json"
+    try:
+        cache_file = _benchmark_cache_path(repo)
+    except ValueError:
+        # Silently reject malicious repo names — do not write anywhere
+        return
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(
         json.dumps(

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from pathlib import Path
 
+from gearbox.agents.audit import _cache_benchmarks, _get_cached_benchmarks
 from gearbox.agents.shared import clone_repository, scanner
 from gearbox.agents.shared.scanner import scan_repository
 
@@ -120,3 +121,90 @@ dev = ["pytest"]
     assert "--known-first-party" in captured_cmd
     assert "demo_package" in captured_cmd
     assert "--optional-dependencies-dev-groups" in captured_cmd
+
+
+# ---------------------------------------------------------------------------
+# Benchmark cache path traversal protection (Issue #51)
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_repo_name_accepts_normal_format() -> None:
+    """Normal owner/repo names must pass sanitization."""
+    from gearbox.agents.audit import _sanitize_repo_name
+
+    assert _sanitize_repo_name("owner/repo") == "owner/repo"
+    assert _sanitize_repo_name("my-org/my-repo_v2") == "my-org/my-repo_v2"
+
+
+def test_sanitize_repo_name_rejects_dotdot() -> None:
+    """Repo names containing '..' must be rejected."""
+    import pytest
+
+    from gearbox.agents.audit import _sanitize_repo_name
+
+    with pytest.raises(ValueError, match="invalid repo"):
+        _sanitize_repo_name("../../etc/evil")
+
+
+def test_sanitize_repo_name_rejects_dots() -> None:
+    """Repo names containing standalone '.' must be rejected."""
+    import pytest
+
+    from gearbox.agents.audit import _sanitize_repo_name
+
+    with pytest.raises(ValueError, match="invalid repo"):
+        _sanitize_repo_name("../secret/backup")
+    with pytest.raises(ValueError, match="invalid repo"):
+        _sanitize_repo_name(".")
+
+
+def test_sanitize_repo_name_rejects_special_chars() -> None:
+    """Repo names with path-special characters must be rejected."""
+    import pytest
+
+    from gearbox.agents.audit import _sanitize_repo_name
+
+    with pytest.raises(ValueError, match="invalid repo"):
+        _sanitize_repo_name("owner/null\x00/repo")
+    with pytest.raises(ValueError, match="invalid repo"):
+        _sanitize_repo_name("owner/../repo")
+
+
+def test_cache_benchmarks_normal_repo_works(tmp_path: Path, monkeypatch) -> None:
+    """Normal owner/repo names should cache and retrieve without error."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("gearbox.agents.audit._BENCHMARK_CACHE_DIR", cache_dir)
+
+    _cache_benchmarks("owner/repo", ["bench/a", "bench/b"])
+    result = _get_cached_benchmarks("owner/repo")
+    assert result == ["bench/a", "bench/b"]
+
+
+def test_cache_benchmarks_rejects_path_traversal_write(tmp_path: Path, monkeypatch) -> None:
+    """Writing with a traversal repo must not create files outside cache dir."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("gearbox.agents.audit._BENCHMARK_CACHE_DIR", cache_dir)
+
+    _cache_benchmarks("../../etc/evil", ["malicious"])
+    evil_file = tmp_path / "etc" / "evil.json"
+    assert not evil_file.exists(), "Path traversal write was not blocked"
+
+
+def test_get_cached_benchmarks_rejects_path_traversal_read(tmp_path: Path, monkeypatch) -> None:
+    """Reading with a traversal repo name must return None (not escape)."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("gearbox.agents.audit._BENCHMARK_CACHE_DIR", cache_dir)
+
+    result = _get_cached_benchmarks("../../etc/passwd")
+    assert result is None, "Path traversal read was not blocked"
+
+
+def test_resolved_cache_path_stays_within_cache_dir(tmp_path: Path, monkeypatch) -> None:
+    """After sanitization, the resolved cache file must be relative to cache dir."""
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setattr("gearbox.agents.audit._BENCHMARK_CACHE_DIR", cache_dir)
+
+    _cache_benchmarks("valid-owner/valid-repo", ["ok"])
+    expected = cache_dir / "valid-owner_valid-repo.json"
+    assert expected.exists()
+    assert expected.resolve().is_relative_to(cache_dir.resolve())


### PR DESCRIPTION
## Summary

Fix path traversal vulnerability in benchmark cache file paths (Issue #51). Added `_sanitize_repo_name()` to validate repo identifiers (whitelist `[a-zA-Z0-9_-/]`, reject `..`, `.`, `//`, and special chars), `_benchmark_cache_path()` with `resolve().is_relative_to()` boundary assertion, and updated both `_get_cached_benchmarks()` / `_cache_benchmarks()` to silently reject malicious inputs. Added 7 tests covering sanitization acceptance/rejection, write blocking, read blocking, and boundary verification.

Closes #51