### PR TITLE
feat(#50): Unified duplicate parse_with_model implementation: deprecated shared/structured.py version to delegate to canonical schemas/__init__.py implementation, eliminating maintenance divergence risk.

### DIFF
--- a/src/gearbox/agents/shared/__init__.py
+++ b/src/gearbox/agents/shared/__init__.py
@@ -5,13 +5,14 @@ from .git import clone_repository
 from .github_output import format_currency, result_to_github_output
 from .runtime import SdkEventLogger, prepare_agent_options
 from .selection import select_best_result
-from .structured import json_schema_output, parse_structured_output
+from .structured import json_schema_output, parse_structured_output, parse_with_model
 
 __all__ = [
     "clone_repository",
     "format_currency",
     "json_schema_output",
     "parse_structured_output",
+    "parse_with_model",
     "prepare_agent_options",
     "read_json_artifact",
     "result_to_github_output",

--- a/src/gearbox/agents/shared/structured.py
+++ b/src/gearbox/agents/shared/structured.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, TypeVar, cast
+import warnings
+from typing import Any, Callable, TypeVar
 
 from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
-from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
 
@@ -32,21 +32,19 @@ def parse_structured_output(
 def parse_with_model(message: object, model_class: type[T]) -> T | None:
     """提取 structured output 并通过 Pydantic model_validate 校验。
 
-    比手写 lambda 更安全：类型错误会抛出精确的 ValidationError，
-    而不是模糊的 ValueError 或 KeyError。
+    .. deprecated::
+        此函数已迁移至 :mod:`gearbox.agents.schemas`。
+        该实现现在委托给 :func:`gearbox.agents.schemas.parse_with_model`，
+        是唯一的 canonical 实现。
     """
-    raw = _extract_raw_dict(message)
-    if raw is None:
-        return None
-    try:
-        return cast(T, model_class.model_validate(raw))  # type: ignore[attr-defined]
-    except ValidationError as e:
-        logger.warning(
-            "Structured output validation failed for %s: %s",
-            model_class.__name__,
-            e,
-        )
-        raise
+    warnings.warn(
+        "parse_with_model is deprecated: use gearbox.agents.schemas.parse_with_model instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    from gearbox.agents.schemas import parse_with_model as _canonical
+
+    return _canonical(message, model_class)  # type: ignore[type-var]
 
 
 def _extract_raw_dict(message: object) -> dict[str, Any] | None:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -469,6 +469,38 @@ class TestStructuredOutputErrorPaths:
             result = parse_with_model(bad_input, BacklogItemResult)
             assert result is None
 
+    def test_shared_structured_parse_with_model_is_deprecated(self) -> None:
+        """shared.structured.parse_with_model 应发出 DeprecationWarning 并委托给 schemas."""
+        import warnings
+
+        from gearbox.agents.schemas import parse_with_model as schemas_parse
+        from gearbox.agents.shared.structured import parse_with_model as shared_parse
+
+        message = self._result(
+            {"labels": ["bug"], "priority": "P1", "complexity": "S", "ready_to_implement": False}
+        )
+
+        # 调用 shared 版本应发出 DeprecationWarning
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = shared_parse(message, BacklogItemResult)
+            # 确认功能正常（向后兼容）
+            assert result is not None
+            assert result.priority == "P1"
+            # 确认发出了 DeprecationWarning
+            deprecation_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(deprecation_warnings) >= 1
+            assert "deprecated" in str(deprecation_warnings[0].message).lower()
+
+        # schemas 版本不应发出警告，且结果一致
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            schemas_result = schemas_parse(message, BacklogItemResult)
+            dep_warnings = [x for x in w if issubclass(x.category, DeprecationWarning)]
+            assert len(dep_warnings) == 0
+        assert schemas_result is not None
+        assert result.model_dump() == schemas_result.model_dump()
+
     # Legacy parse_structured_output backward-compat tests
     def test_legacy_parse_structured_output_none(self) -> None:
         result = parse_structured_output(self._result(None), lambda data: data["key"])


### PR DESCRIPTION
## Summary

Unified duplicate parse_with_model implementation: deprecated shared/structured.py version to delegate to canonical schemas/__init__.py implementation, eliminating maintenance divergence risk.

Closes #50