### PR TITLE
feat(#55): Fix Issue #55: Backlog Agent no longer silently swallows clone failures. Three changes to src/gearbox/agents/backlog.py: (1) Replaced bare `except Exception: pass` with specific `except (RuntimeError, OSError)` that logs a warning via `click.echo(..., err=True)` including the exception type and message; (2) Moved clone logic before prompt construction so a `clone_failed` flag can inject a fallback context notice into the agent prompt ("当前未加载目标仓库源码（克隆失败），请基于 Issue 正文和标签进行分类"); (3) Added `import click` for warning output. Two new tests in tests/test_agents.py (TestBacklogCloneFailure) verify: clone failure produces stderr warning + prompt contains fallback context, and both RuntimeError/OSError are gracefully caught without crashing.

### DIFF
--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -6,6 +6,8 @@ import subprocess
 from pathlib import Path
 from typing import Any, cast
 
+import click
+
 from gearbox.agents.schemas import BacklogItemResult as _BacklogItemResultModel
 
 # Re-export for backward compat
@@ -184,6 +186,31 @@ async def run_backlog_item(
     all_issues = list_open_issues(repo, limit=50)
     issues_summary = format_issues_summary(all_issues, current_issue_number=issue_number)
 
+    clone_root: Path | None = None
+    clone_dir: tempfile.TemporaryDirectory[str] | None = None
+    clone_failed = False
+
+    # 仅远程仓库（owner/repo 格式）需要克隆，本地路径不具备 GitHub API 上下文
+    if "/" in repo:
+        try:
+            clone_root, clone_dir = clone_repository(repo)
+        except (RuntimeError, OSError) as exc:
+            click.echo(
+                f"⚠️ 克隆目标仓库 {repo} 失败 "
+                f"({exc.__class__.__name__}: {exc})，"
+                f"将回退到当前工作目录，Agent 将基于 Issue 正文进行分类。",
+                err=True,
+            )
+            clone_failed = True
+
+    cwd = clone_root if clone_root else Path.cwd()
+
+    _clone_fallback_notice = (
+        "\n> **注意**: 当前未加载目标仓库源码（克隆失败），请基于 Issue 正文和标签进行分类。\n"
+        if clone_failed
+        else ""
+    )
+
     prompt = f"""## 当前 Issue 信息
 
 **仓库**: {repo}
@@ -197,20 +224,8 @@ async def run_backlog_item(
 
 ## {issues_summary}
 
----
+{_clone_fallback_notice}---
 {SYSTEM_PROMPT}"""
-
-    clone_root: Path | None = None
-    clone_dir: tempfile.TemporaryDirectory[str] | None = None
-
-    # 仅远程仓库（owner/repo 格式）需要克隆，本地路径不具备 GitHub API 上下文
-    if "/" in repo:
-        try:
-            clone_root, clone_dir = clone_repository(repo)
-        except Exception:
-            pass  # 克隆失败时 cwd 未定义，由 Agent 自行处理
-
-    cwd = clone_root if clone_root else Path.cwd()
 
     options, sdk_logger = prepare_agent_options(
         ClaudeAgentOptions(

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -477,3 +477,138 @@ class TestStructuredOutputErrorPaths:
     def test_legacy_parse_structured_output_string(self) -> None:
         result = parse_structured_output(self._result("not a dict"), lambda data: data["key"])
         assert result is None
+
+
+class TestBacklogCloneFailure:
+    """验证 run_backlog_item 在克隆失败时的行为（Issue #55）。"""
+
+    def test_clone_failure_logs_warning_and_injects_fallback_context(
+        self, monkeypatch, capsys
+    ) -> None:
+        """克隆失败时应输出 warning 日志，并在 prompt 中注入回退上下文标注。"""
+        import asyncio
+
+        captured_prompt: dict[str, str] = {}
+        captured_options: dict[str, object] = {}
+
+        async def fake_query(*args, **kwargs):
+            captured_prompt["text"] = args[0] if args else kwargs.get("prompt", "")
+            captured_options.update(
+                kwargs.get("options", {}).__dict__ if "options" in kwargs else {}
+            )
+            yield _result_message(
+                {
+                    "labels": ["bug"],
+                    "priority": "P2",
+                    "complexity": "S",
+                    "ready_to_implement": False,
+                }
+            )
+
+        class FakeLogger:
+            def log_start(self, **kwargs) -> None:
+                pass
+
+            def handle_message(self, *args, **kwargs) -> None:
+                pass
+
+            def log_completion(self) -> None:
+                pass
+
+        def fake_prepare_agent_options(options, agent_name):
+            return options, FakeLogger()
+
+        # 让 clone_repository 抛出 RuntimeError
+        def fake_clone_raises(repo):
+            raise RuntimeError(f"clone failed for {repo}: not found")
+
+        monkeypatch.setattr(
+            backlog,
+            "_gh_issue_view",
+            lambda *a, **kw: {
+                "title": "Test Issue",
+                "body": "Something is broken",
+                "labels": ["bug"],
+            },
+        )
+        monkeypatch.setattr("gearbox.core.gh.list_open_issues", lambda *a, **kw: [])
+        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr(
+            "gearbox.agents.shared.runtime.prepare_agent_options",
+            fake_prepare_agent_options,
+        )
+        monkeypatch.setattr(
+            "gearbox.agents.shared.clone_repository",
+            fake_clone_raises,
+        )
+
+        result = asyncio.run(backlog.run_backlog_item("owner/nonexistent", 42, model="test-model"))
+
+        # 1. 函数不应崩溃，应正常返回结果
+        assert result is not None
+        assert result.labels == ["bug"]
+
+        # 2. 应输出 warning 级别日志（包含 clone 失败信息）
+        output = capsys.readouterr()
+        assert "clone" in output.err.lower() or "clone" in output.out.lower()
+
+        # 3. prompt 中应包含回退上下文标注
+        prompt_text = captured_prompt.get("text", "")
+        assert "未加载目标仓库源码" in prompt_text or "未加载" in prompt_text
+
+    def test_clone_failure_catches_specific_exceptions_not_bare_exception(
+        self, monkeypatch, capsys
+    ) -> None:
+        """验证克隆失败时捕获的是特定异常类型而非 bare Exception。"""
+        import asyncio
+
+        async def fake_query(*args, **kwargs):
+            yield _result_message(
+                {
+                    "labels": ["enhancement"],
+                    "priority": "P3",
+                    "complexity": "S",
+                    "ready_to_implement": False,
+                }
+            )
+
+        class FakeLogger:
+            def log_start(self, **kwargs) -> None:
+                pass
+
+            def handle_message(self, *args, **kwargs) -> None:
+                pass
+
+            def log_completion(self) -> None:
+                pass
+
+        def fake_prepare_agent_options(options, agent_name):
+            return options, FakeLogger()
+
+        # 用 OSError 测试——应在特定异常捕获范围内
+        def fake_clone_oserror(repo):
+            raise OSError("network unreachable")
+
+        monkeypatch.setattr(
+            backlog,
+            "_gh_issue_view",
+            lambda *a, **kw: {
+                "title": "Test",
+                "body": "Body",
+                "labels": [],
+            },
+        )
+        monkeypatch.setattr("gearbox.core.gh.list_open_issues", lambda *a, **kw: [])
+        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr(
+            "gearbox.agents.shared.runtime.prepare_agent_options",
+            fake_prepare_agent_options,
+        )
+        monkeypatch.setattr(
+            "gearbox.agents.shared.clone_repository",
+            fake_clone_oserror,
+        )
+
+        # 不应抛出异常，应优雅降级
+        result = asyncio.run(backlog.run_backlog_item("owner/repo", 1, model="test-model"))
+        assert result is not None


### PR DESCRIPTION
## Summary

Fix Issue #55: Backlog Agent no longer silently swallows clone failures. Three changes to src/gearbox/agents/backlog.py: (1) Replaced bare `except Exception: pass` with specific `except (RuntimeError, OSError)` that logs a warning via `click.echo(..., err=True)` including the exception type and message; (2) Moved clone logic before prompt construction so a `clone_failed` flag can inject a fallback context notice into the agent prompt ("当前未加载目标仓库源码（克隆失败），请基于 Issue 正文和标签进行分类"); (3) Added `import click` for warning output. Two new tests in tests/test_agents.py (TestBacklogCloneFailure) verify: clone failure produces stderr warning + prompt contains fallback context, and both RuntimeError/OSError are gracefully caught without crashing.

Closes #55