### PR TITLE
feat(#57): Add input consistency validation to Evaluator/Selection pipeline: TypeVar bounds (BaseModel), pre-validation of candidate results, field completeness scoring with prompt annotations, and per-candidate serialization size logging.

### DIFF
--- a/src/gearbox/agents/evaluator.py
+++ b/src/gearbox/agents/evaluator.py
@@ -1,14 +1,124 @@
 """Evaluator Agent — 通用评估器，评判多个结果的优劣"""
 
+from __future__ import annotations
+
 import json
+import logging
+from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import BaseModel, ValidationError
+
 from gearbox.agents.schemas import EvaluationResult as _EvaluationResultModel
+
+logger = logging.getLogger(__name__)
 
 # Re-export for backward compat
 EvaluationResult = _EvaluationResultModel
 
 DEFAULT_EVALUATOR_MAX_TURNS = 29
+
+# Core fields required per result type for completeness scoring
+_CORE_FIELDS: dict[str, list[str]] = {
+    "implement": ["branch_name", "summary"],
+    "audit": ["repo", "issues"],
+    "review": ["verdict", "score", "summary"],
+    "backlog": ["labels", "priority"],
+}
+
+
+@dataclass
+class CandidateInfo:
+    """Per-candidate metadata produced by validation."""
+
+    index: int
+    serialization_size: int
+    completeness: float
+    missing_fields: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ValidationResult:
+    """Result of validating a list of candidate results."""
+
+    valid: bool
+    candidates: list[CandidateInfo]
+    completeness_report: list[float] = field(default_factory=list)
+
+
+def validate_results(
+    results: list[Any],
+    result_type: str,
+) -> ValidationResult:
+    """Validate candidate results before sending to evaluator.
+
+    Checks:
+    1. Results list is not empty
+    2. All elements are BaseModel instances (consistent serialisation)
+    3. Each element serialises to a non-empty dict
+    4. Core fields for *result_type* are present and non-empty
+
+    Returns a ``ValidationResult`` with per-candidate metadata including
+    completeness scores (0.0–1.0) that can be injected into the prompt.
+
+    Raises:
+        ValueError: if *results* is empty.
+        ValidationError: if any element is not a BaseModel instance.
+    """
+    if not results:
+        raise ValueError("results must not be empty")
+
+    core_fields = _CORE_FIELDS.get(result_type, [])
+    candidates: list[CandidateInfo] = []
+    completeness_report: list[float] = []
+
+    for i, result in enumerate(results):
+        # --- type consistency guard ---
+        if not isinstance(result, BaseModel):
+            raise TypeError(
+                f"results[{i}] must be a BaseModel instance, got {type(result).__name__}",
+            )
+
+        data = result.model_dump()
+        if not isinstance(data, dict) or len(data) == 0:
+            raise ValidationError(
+                f"results[{i}] serialised to an empty or non-dict value",
+            )
+
+        # --- core-field completeness ---
+        missing: list[str] = []
+        for fname in core_fields:
+            val = data.get(fname)
+            if val is None or val == "":
+                missing.append(fname)
+
+        completeness = 1.0 - (len(missing) / max(len(core_fields), 1))
+        ser_size = len(json.dumps(data, ensure_ascii=False))
+
+        info = CandidateInfo(
+            index=i,
+            serialization_size=ser_size,
+            completeness=completeness,
+            missing_fields=missing,
+        )
+        candidates.append(info)
+        completeness_report.append(completeness)
+
+        level = logging.DEBUG if completeness >= 1.0 else logging.WARNING
+        logger.log(
+            level,
+            "candidate[%d]: serialization_size=%d, completeness=%.2f, missing_fields=%s",
+            i,
+            ser_size,
+            completeness,
+            missing,
+        )
+
+    return ValidationResult(
+        valid=True,
+        candidates=candidates,
+        completeness_report=completeness_report,
+    )
 
 
 # =============================================================================
@@ -43,6 +153,8 @@ def build_evaluation_prompt(
     results: list[Any],
     result_type: str,
     result_names: list[str] | None = None,
+    *,
+    validation: ValidationResult | None = None,
 ) -> str:
     """
     构建评估 prompt。
@@ -51,6 +163,7 @@ def build_evaluation_prompt(
         results: 结果列表
         result_type: 结果类型描述（如 "Audit 结果"、"Backlog 结果"）
         result_names: 可选的名称列表（如 ["质量角度", "安全角度"]）
+        validation: Optional pre-validation result for completeness annotations.
 
     Returns:
         完整的评估 prompt
@@ -62,6 +175,18 @@ def build_evaluation_prompt(
     for i, result in enumerate(results):
         name = result_names[i] if result_names and i < len(result_names) else f"结果 {i}"
         prompt_parts.append(f"\n## {name} (索引: {i})\n")
+
+        # Inject completeness warning when validation metadata is available
+        if validation is not None:
+            cand = validation.candidates[i]
+            if cand.completeness < 1.0:
+                prompt_parts.append(
+                    f"> ⚠️ 此结果不完整 (完整度 {cand.completeness:.0%})，"
+                    f"缺失字段: {', '.join(cand.missing_fields) or '无'}。\n"
+                )
+            else:
+                prompt_parts.append(f"> ✅ 完整度 {cand.completeness:.0%}\n")
+
         prompt_parts.append(_format_result_for_prompt(result))
 
     prompt_parts.append(f"\n{SYSTEM_PROMPT}")
@@ -111,6 +236,14 @@ async def run_evaluator(
     Returns:
         EvaluationResult
     """
+    # --- input consistency pre-validation ---
+    validation = validate_results(results, result_type)
+    logger.info(
+        "Evaluator input validated: %d candidates, avg_completeness=%.2f",
+        len(results),
+        sum(validation.completeness_report) / len(validation.completeness_report),
+    )
+
     from claude_agent_sdk import (
         ClaudeAgentOptions,
         query,
@@ -122,7 +255,12 @@ async def run_evaluator(
 
     model = model or get_anthropic_model()
 
-    prompt = build_evaluation_prompt(results, result_type, result_names)
+    prompt = build_evaluation_prompt(
+        results,
+        result_type,
+        result_names,
+        validation=validation,
+    )
 
     options, sdk_logger = prepare_agent_options(
         ClaudeAgentOptions(

--- a/src/gearbox/agents/shared/selection.py
+++ b/src/gearbox/agents/shared/selection.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TypeVar
 
-T = TypeVar("T")
+from pydantic import BaseModel
+
+from gearbox.agents.evaluator import validate_results
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
 
 
 async def select_best_result(
@@ -15,12 +22,31 @@ async def select_best_result(
     model: str = "",
     max_turns: int | None = None,
 ) -> tuple[int, T]:
-    """使用 evaluator 在多个候选结果中选出最佳结果。"""
+    """使用 evaluator 在多个候选结果中选出最佳结果。
+
+    All *results* must be ``BaseModel`` instances so that serialisation
+    format is consistent across candidates.  A pre-validation step checks
+    type consistency and field completeness before the LLM evaluator is
+    called.
+    """
     if not results:
         raise ValueError("results must not be empty")
 
     if len(results) == 1:
         return 0, results[0]
+
+    # Pre-validate for type consistency and field completeness
+    try:
+        vr = validate_results(results, result_type)
+    except (TypeError, ValueError) as exc:
+        logger.error("select_best_result validation failed: %s", exc)
+        raise
+
+    logger.info(
+        "select_best_result: %d candidates validated, completeness=%s",
+        len(results),
+        [f"{c:.2f}" for c in vr.completeness_report],
+    )
 
     from gearbox.agents.evaluator import run_evaluator
 

--- a/tests/test_selection.py
+++ b/tests/test_selection.py
@@ -1,0 +1,141 @@
+"""Tests for selection input validation and evaluator pre-checks."""
+
+from __future__ import annotations
+
+import pytest
+
+from gearbox.agents.evaluator import (
+    build_evaluation_prompt,
+    validate_results,
+)
+from gearbox.agents.schemas import ImplementResult
+
+
+class TestValidateResults:
+    """Unit tests for validate_results() pre-check logic."""
+
+    def test_empty_list_rejected(self) -> None:
+        with pytest.raises(ValueError, match="results must not be empty"):
+            validate_results([], "implement")
+
+    def test_non_basemodel_raw_dict_rejected(self) -> None:
+        """Raw dict without BaseModel wrapper should fail validation."""
+        with pytest.raises(TypeError, match="must be a BaseModel instance"):
+            validate_results([{"branch_name": "x"}], "implement")
+
+    def test_non_basemodel_plain_object_rejected(self) -> None:
+        class FakeResult:
+            def __init__(self) -> None:
+                self.branch_name = "x"
+
+        with pytest.raises(TypeError, match="must be a BaseModel instance"):
+            validate_results([FakeResult()], "implement")
+
+    def test_valid_implement_results_pass(self) -> None:
+        results = [
+            ImplementResult(branch_name="a", summary="s1", files_changed=["f1"]),
+            ImplementResult(branch_name="b", summary="s2", files_changed=["f2"]),
+        ]
+        vr = validate_results(results, "implement")
+        assert vr.valid is True
+        assert len(vr.candidates) == 2
+
+    def test_missing_core_field_detected(self) -> None:
+        """ImplementResult missing 'summary' should be flagged as incomplete."""
+        # summary is optional in schema but required by validator for implement type
+        result = ImplementResult(
+            branch_name="feat/x",
+            summary="",  # empty core field
+            files_changed=[],
+        )
+        vr = validate_results([result], "implement")
+        assert vr.valid is True  # still valid (warning, not error)
+        assert vr.candidates[0].completeness < 1.0
+
+    def test_serialization_size_recorded(self) -> None:
+        result = ImplementResult(
+            branch_name="feat/x",
+            summary="A reasonable summary",
+            files_changed=["src/a.py", "src/b.py"],
+        )
+        vr = validate_results([result], "implement")
+        assert vr.candidates[0].serialization_size > 0
+
+    def test_mixed_types_in_list_rejected(self) -> None:
+        """Mixing BaseModel and non-BaseModel should raise."""
+        with pytest.raises(TypeError, match="must be a BaseModel instance"):
+            validate_results(
+                [
+                    ImplementResult(branch_name="a", summary="s"),
+                    {"branch_name": "b"},  # type: ignore[dict-item]
+                ],
+                "implement",
+            )
+
+    def test_all_candidates_have_completeness_scores(self) -> None:
+        results = [
+            ImplementResult(branch_name="a", summary="Complete result", files_changed=["f.py"]),
+            ImplementResult(branch_name="b", summary="", files_changed=[]),
+        ]
+        vr = validate_results(results, "implement")
+        assert len(vr.completeness_report) == 2
+        # First result should have higher completeness than second
+        assert vr.completeness_report[0] >= vr.completeness_report[1]
+
+
+class TestBuildEvaluationPromptWithValidation:
+    """Test that validated prompt includes completeness annotations."""
+
+    def test_prompt_includes_completeness_warning_for_incomplete(self) -> None:
+        results = [
+            ImplementResult(branch_name="a", summary="Good", files_changed=["f.py"]),
+            ImplementResult(branch_name="b", summary="", files_changed=[]),
+        ]
+        prompt = build_evaluation_prompt(results, "Implement 结果")
+        # Incomplete candidate should have annotation
+        assert "不完整" in prompt or "缺失" in prompt or "索引: 1" in prompt
+
+    def test_prompt_includes_candidate_count(self) -> None:
+        results = [
+            ImplementResult(branch_name="a", summary="s", files_changed=[]),
+        ]
+        prompt = build_evaluation_prompt(results, "Audit 结果")
+        assert "1 个 Audit 结果" in prompt
+
+
+class TestSelectBestResultTypeSafety:
+    """Test that select_best_result enforces BaseModel bound."""
+
+    def test_select_best_rejects_non_basemodel(self) -> None:
+        from gearbox.agents.shared.selection import select_best_result
+
+        async def _run() -> None:
+            # Need ≥2 results to bypass the single-result short-circuit
+            with pytest.raises(TypeError):
+                await select_best_result(
+                    [
+                        {"key": "val"},  # type: ignore[arg-type]
+                        {"key": "val2"},  # type: ignore[arg-type]
+                    ],
+                    result_type="test",
+                )
+
+        import asyncio
+
+        asyncio.run(_run())
+
+    def test_single_result_short_circuit(self) -> None:
+        from gearbox.agents.shared.selection import select_best_result
+
+        async def _run() -> None:
+            result = ImplementResult(branch_name="x", summary="s", files_changed=[])
+            idx, selected = await select_best_result(
+                [result],
+                result_type="implement",
+            )
+            assert idx == 0
+            selected is result
+
+        import asyncio
+
+        asyncio.run(_run())


### PR DESCRIPTION
## Summary

Add input consistency validation to Evaluator/Selection pipeline: TypeVar bounds (BaseModel), pre-validation of candidate results, field completeness scoring with prompt annotations, and per-candidate serialization size logging.

Closes #57