### PR TITLE
feat(#60): Fix Issue #60: Add mtime-based lazy caching to `load_config()` in settings.py to eliminate redundant TOML file I/O on every config access and prevent TOCTOU race conditions.

**Changes:**
- **`src/gearbox/config/settings.py`**: Added module-level `_cached_config` / `_cache_mtime` lazy cache. `load_config()` now checks `os.path.getmtime()` before re-reading — returns cached dict (same object identity) when file hasn't changed. Added `reload_config()` for explicit cache invalidation. Added `logging.debug()` for cache hit/miss events.
- **`src/gearbox/config/__init__.py`**: Exported new `reload_config()`.
- **`tests/test_config.py`**: Added 4 TDD tests in `TestConfigCache`: cache object identity, mtime-based invalidation, forced reload via `reload_config()`, and getter consistency (no TOCTOU).

**Verification:** 22/22 config tests pass, ruff clean, mypy clean. Pre-existing failure in `test_flow.py` is unrelated.

### DIFF
--- a/src/gearbox/config/__init__.py
+++ b/src/gearbox/config/__init__.py
@@ -9,6 +9,7 @@ from .settings import (
     get_config_path,
     get_github_token,
     load_config,
+    reload_config,
     save_config,
     set_anthropic_api_key,
     set_anthropic_base_url,
@@ -30,6 +31,7 @@ __all__ = [
     "set_anthropic_model",
     "set_provider",
     "load_config",
+    "reload_config",
     "save_config",
     "get_config_path",
 ]

--- a/src/gearbox/config/settings.py
+++ b/src/gearbox/config/settings.py
@@ -1,10 +1,17 @@
 """配置管理 - 读写用户配置"""
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, cast
 
 import tomli_w
+
+logger = logging.getLogger(__name__)
+
+# 模块级惰性缓存 (Issue #60)
+_cached_config: dict[str, Any] | None = None
+_cache_mtime: float = 0.0
 
 # Agent 默认参数（CLI 和 Action 均引用此处的值）
 AGENT_DEFAULTS: dict[str, Any] = {
@@ -36,20 +43,51 @@ def get_config_path() -> Path:
 
 
 def load_config() -> dict[str, Any]:
-    """加载配置文件"""
+    """加载配置文件（带 mtime 惰性缓存，避免重复 I/O）"""
+    global _cached_config, _cache_mtime
+
     config_file = get_config_path()
+
+    # 文件不存在时返回空字典（不缓存，因为文件可能被创建）
     if not config_file.exists():
+        _cached_config = None
+        _cache_mtime = 0.0
         return {}
 
+    try:
+        current_mtime = os.path.getmtime(config_file)
+    except OSError:
+        current_mtime = 0.0
+
+    # 缓存命中：文件未变更
+    if _cached_config is not None and current_mtime == _cache_mtime and current_mtime > 0:
+        logger.debug("config cache hit (mtime=%s)", current_mtime)
+        return _cached_config
+
+    # 缓存未命中或文件已变更，重新加载
     try:
         import tomli
 
         with open(config_file, "rb") as f:
-            return tomli.load(f)
+            _cached_config = tomli.load(f)
+        _cache_mtime = current_mtime
+        logger.debug("config cache miss – reloaded (mtime=%s)", current_mtime)
+        return _cached_config
     except ImportError:
         return {}
     except Exception:
         return {}
+
+
+def reload_config() -> dict[str, Any]:
+    """强制重新加载配置文件，清除缓存。
+
+    用于需要热更新配置的场景（如用户手动编辑后）。
+    """
+    global _cached_config, _cache_mtime
+    _cached_config = None
+    _cache_mtime = 0.0
+    return load_config()
 
 
 def save_config(config: dict[str, Any]) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,11 @@
 """测试 config 模块"""
 
+import logging
 import os
+import time
 from pathlib import Path
+
+import pytest
 
 from gearbox.config import (
     AGENT_DEFAULTS,
@@ -12,6 +16,7 @@ from gearbox.config import (
     get_config_path,
     get_github_token,
     load_config,
+    reload_config,
     save_config,
 )
 
@@ -176,3 +181,75 @@ class TestAgentDefaults:
         assert "implement" in AGENT_DEFAULTS["max_turns"]
         assert "audit" in AGENT_DEFAULTS["max_turns"]
         assert AGENT_DEFAULTS["max_turns"]["implement"] == 80
+
+
+class TestConfigCache:
+    """测试配置缓存行为 (Issue #60)"""
+
+    def test_multiple_loads_return_cached_object(self, temp_home: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """连续多次 load_config 应返回缓存对象（同一 identity），避免重复 I/O"""
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+        save_config({"anthropic_model": "cached-model-v1"})
+
+        with caplog.at_level(logging.DEBUG, logger="gearbox.config.settings"):
+            first = load_config()
+            second = load_config()
+            third = load_config()
+
+        # 后续调用应返回同一对象（缓存命中）
+        assert first is second is third
+        # 应有 cache hit 日志
+        assert any("cache hit" in r.message.lower() for r in caplog.records)
+
+    def test_cache_invalidated_on_file_change(self, temp_home: Path) -> None:
+        """文件修改后，下次 load_config 应重新读取"""
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+        save_config({"anthropic_model": "model-v1"})
+
+        first = load_config()
+        assert first["anthropic_model"] == "model-v1"
+
+        # 修改文件
+        time.sleep(0.05)  # 确保 mtime 变化
+        save_config({"anthropic_model": "model-v2"})
+
+        second = load_config()
+        assert second["anthropic_model"] == "model-v2"
+        # 对象 identity 不同（缓存失效后重新加载）
+        assert first is not second
+
+    def test_reload_config_forces_refresh(self, temp_home: Path) -> None:
+        """reload_config() 应强制刷新缓存，即使文件未变"""
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+        save_config({"key": "original"})
+
+        first = load_config()
+
+        # 不改文件，强制 reload
+        reloaded = reload_config()
+        assert reloaded["key"] == "original"
+        # reload 返回新对象
+        assert first is not reloaded
+
+    def test_getters_use_cache_consistently(self, temp_home: Path) -> None:
+        """getter 函数在单次事务内应读到一致的配置快照（无 TOCTOU）"""
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+        save_config({
+            "anthropic_api_key": "key-for-model-x",
+            "anthropic_model": "model-x",
+        })
+
+        # 连续调用多个 getter，应全部命中缓存并返回一致数据
+        key1 = get_anthropic_api_key()
+        model1 = get_anthropic_model()
+        key2 = get_anthropic_api_key()
+        model2 = get_anthropic_model()
+
+        assert key1 == "key-for-model-x"
+        assert model1 == "model-x"
+        assert key1 == key2
+        assert model1 == model2


### PR DESCRIPTION
## Summary

Fix Issue #60: Add mtime-based lazy caching to `load_config()` in settings.py to eliminate redundant TOML file I/O on every config access and prevent TOCTOU race conditions.

**Changes:**
- **`src/gearbox/config/settings.py`**: Added module-level `_cached_config` / `_cache_mtime` lazy cache. `load_config()` now checks `os.path.getmtime()` before re-reading — returns cached dict (same object identity) when file hasn't changed. Added `reload_config()` for explicit cache invalidation. Added `logging.debug()` for cache hit/miss events.
- **`src/gearbox/config/__init__.py`**: Exported new `reload_config()`.
- **`tests/test_config.py`**: Added 4 TDD tests in `TestConfigCache`: cache object identity, mtime-based invalidation, forced reload via `reload_config()`, and getter consistency (no TOCTOU).

**Verification:** 22/22 config tests pass, ruff clean, mypy clean. Pre-existing failure in `test_flow.py` is unrelated.

Closes #60