### PR TITLE
feat(#65): Fix load_config() silently swallowing all exceptions by adding logging.warning for non-FileNotFoundError exceptions. The bare `except Exception: return {}` was replaced with explicit handling: `FileNotFoundError` continues to return `{}` silently (file simply doesn't exist), while all other exceptions (TOML parse errors, permission errors, encoding issues) now log a warning with the config file path and exception details before falling back to `{}`. Two new tests verify: (1) corrupt TOML triggers a warning log, and (2) missing file produces no warning.

### DIFF
--- a/src/gearbox/config/settings.py
+++ b/src/gearbox/config/settings.py
@@ -1,10 +1,13 @@
 """配置管理 - 读写用户配置"""
 
+import logging
 import os
 from pathlib import Path
 from typing import Any, cast
 
 import tomli_w
+
+logger = logging.getLogger(__name__)
 
 # Agent 默认参数（CLI 和 Action 均引用此处的值）
 AGENT_DEFAULTS: dict[str, Any] = {
@@ -48,7 +51,10 @@ def load_config() -> dict[str, Any]:
             return tomli.load(f)
     except ImportError:
         return {}
-    except Exception:
+    except FileNotFoundError:
+        return {}
+    except Exception as exc:
+        logger.warning("Failed to load config from %s: %s", config_file, exc)
         return {}
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,10 @@
 """测试 config 模块"""
 
+import logging
 import os
 from pathlib import Path
+
+import pytest
 
 from gearbox.config import (
     AGENT_DEFAULTS,
@@ -34,6 +37,33 @@ class TestLoadConfig:
     def test_returns_dict(self) -> None:
         result = load_config()
         assert isinstance(result, dict)
+
+    def test_logs_warning_on_corrupt_toml(self, temp_home: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """损坏的 TOML 配置文件应记录 warning 日志，而非静默吞没异常"""
+        config_dir = temp_home / ".config" / "gearbox"
+        config_dir.mkdir(parents=True)
+        config_file = config_dir / "config.toml"
+        config_file.write_text("this is not valid [toml\n")
+
+        with caplog.at_level(logging.WARNING, logger="gearbox.config"):
+            result = load_config()
+
+        assert result == {}
+        assert any(
+            "Failed to load config" in rec.message for rec in caplog.records
+        ), f"Expected warning log about failed config load, got: {[rec.message for rec in caplog.records]}"
+
+    def test_no_warning_when_file_not_found(self, temp_home: Path, caplog: pytest.LogCaptureFixture) -> None:
+        """配置文件不存在时不应记录警告"""
+        # 不创建配置文件，确保它不存在
+
+        with caplog.at_level(logging.WARNING, logger="gearbox.config"):
+            result = load_config()
+
+        assert result == {}
+        assert not any(
+            "Failed to load config" in rec.message for rec in caplog.records
+        )
 
 
 class TestSaveConfig:


### PR DESCRIPTION
## Summary

Fix load_config() silently swallowing all exceptions by adding logging.warning for non-FileNotFoundError exceptions. The bare `except Exception: return {}` was replaced with explicit handling: `FileNotFoundError` continues to return `{}` silently (file simply doesn't exist), while all other exceptions (TOML parse errors, permission errors, encoding issues) now log a warning with the config file path and exception details before falling back to `{}`. Two new tests verify: (1) corrupt TOML triggers a warning log, and (2) missing file produces no warning.

Closes #65