### PR TITLE
feat(#69): Fix VALID_ISSUE_LABELS whitelist being too narrow, causing Backlog Agent labels (refactor, performance, cleanup) to be silently dropped by create_issue(). Changes: (1) Added refactor, performance, cleanup to VALID_ISSUE_LABELS set in core/gh.py; (2) Added logger.warning() when labels are filtered out so dropped labels are visible in logs instead of silently discarded. TDD-driven with 3 new tests validating the fix.

### DIFF
--- a/src/gearbox/core/gh.py
+++ b/src/gearbox/core/gh.py
@@ -1,10 +1,13 @@
 """GitHub 操作模块 - 集中管理所有 gh/git 操作"""
 
 import json
+import logging
 import os
 import subprocess
 from dataclasses import dataclass
 from typing import Any
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -744,6 +747,9 @@ VALID_ISSUE_LABELS = {
     # Categories
     "security",
     "ci",
+    "refactor",
+    "performance",
+    "cleanup",
 }
 
 
@@ -788,6 +794,12 @@ def create_issue(
 
     issue_number = int(match.group(1))
     filtered = [label for label in labels if label in VALID_ISSUE_LABELS]
+    dropped = [label for label in labels if label not in VALID_ISSUE_LABELS]
+    if dropped:
+        logger.warning(
+            "create_issue: 以下标签不在 VALID_ISSUE_LABELS 白名单中，已被丢弃: %s",
+            ", ".join(dropped),
+        )
     if filtered:
         label_result = add_issue_labels(repo, issue_number, filtered)
         if not label_result.success:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -536,3 +536,52 @@ class TestValidIssueLabels:
         from gearbox.core.gh import VALID_ISSUE_LABELS
 
         assert isinstance(VALID_ISSUE_LABELS, (set, frozenset))
+
+    def test_contains_backlog_agent_labels(self) -> None:
+        """Backlog Agent SYSTEM_PROMPT 允许产出的标签必须在白名单中。"""
+        backlog_labels = {"refactor", "performance", "cleanup"}
+        assert backlog_labels.issubset(
+            VALID_ISSUE_LABELS
+        ), f"VALID_ISSUE_LABELS 缺少 Backlog Agent 使用的标签: {backlog_labels - VALID_ISSUE_LABELS}"
+
+
+class TestCreateIssueLabelWarning:
+    """测试 create_issue 对被过滤标签的警告日志"""
+
+    def test_warns_when_labels_are_filtered_out(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            del kwargs
+            return MagicMock(returncode=0, stdout="https://github.com/owner/repo/issues/42\n")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+        # 不 mock add_issue_labels，让真实过滤逻辑执行
+
+        with caplog.at_level(logging.WARNING, logger="gearbox"):
+            create_issue("owner/repo", "Title", "Body", ["enhancement", "unknown-label", "P1"])
+
+        assert any(
+            "unknown-label" in rec.message and rec.levelno == logging.WARNING
+            for rec in caplog.records
+        ), "被过滤的标签应产生 WARNING 日志"
+
+    def test_does_not_warn_when_all_labels_valid(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import logging
+
+        def fake_run(cmd: list[str], **kwargs: Any) -> MagicMock:
+            del kwargs
+            return MagicMock(returncode=0, stdout="https://github.com/owner/repo/issues/42\n")
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        with caplog.at_level(logging.WARNING, logger="gearbox"):
+            create_issue("owner/repo", "Title", "Body", ["refactor", "P2"])
+
+        assert not any(
+            rec.levelno == logging.WARNING for rec in caplog.records
+        ), "所有标签合法时不应产生 WARNING 日志"


### PR DESCRIPTION
## Summary

Fix VALID_ISSUE_LABELS whitelist being too narrow, causing Backlog Agent labels (refactor, performance, cleanup) to be silently dropped by create_issue(). Changes: (1) Added refactor, performance, cleanup to VALID_ISSUE_LABELS set in core/gh.py; (2) Added logger.warning() when labels are filtered out so dropped labels are visible in logs instead of silently discarded. TDD-driven with 3 new tests validating the fix.

Closes #69