### PR TITLE
feat(#75): Fix #75: Add `run_id` keyword-only parameter to `dispatch_branch_name()` to prevent branch name collisions when the same issue is dispatched multiple times (Fix Loop retry scenario). The function now accepts `run_id` (default 0) and embeds it in the branch name as `feat/issue-{N}-run-{run_id}`. All existing callers are backward-compatible via the default value. Two new tests cover run_id embedding and default behavior.

### DIFF
--- a/src/gearbox/flow/dispatch.py
+++ b/src/gearbox/flow/dispatch.py
@@ -11,9 +11,13 @@ COMPLEXITY_ORDER = {"S": 0, "M": 1, "L": 2}
 BLOCKING_LABELS = {"needs-clarification", "in-progress", "has-pr"}
 
 
-def dispatch_branch_name(issue_number: int) -> str:
-    """Return the deterministic implementation branch for an issue."""
-    return f"feat/issue-{issue_number}-run-0"
+def dispatch_branch_name(issue_number: int, *, run_id: int = 0) -> str:
+    """Return the deterministic implementation branch for an issue.
+
+    The ``run_id`` distinguishes multiple dispatches of the same issue
+    (e.g. Fix Loop retries) so that each attempt gets a unique branch name.
+    """
+    return f"feat/issue-{issue_number}-run-{run_id}"
 
 
 def _label_value(labels: list[str], allowed: dict[str, int], default: str) -> str:

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -204,6 +204,18 @@ def test_dispatch_branch_name_format_for_large_numbers() -> None:
     assert dispatch_branch_name(999) == "feat/issue-999-run-0"
 
 
+def test_dispatch_branch_name_includes_run_id() -> None:
+    """run_id 参数应出现在分支名中，避免同 Issue 重复派发时碰撞"""
+    assert dispatch_branch_name(2, run_id=0) == "feat/issue-2-run-0"
+    assert dispatch_branch_name(2, run_id=1) == "feat/issue-2-run-1"
+    assert dispatch_branch_name(17, run_id=3) == "feat/issue-17-run-3"
+
+
+def test_dispatch_branch_name_default_run_id_is_zero() -> None:
+    """不传 run_id 时默认为 0，保持向后兼容"""
+    assert dispatch_branch_name(5) == "feat/issue-5-run-0"
+
+
 def test_build_dispatch_plan_raises_on_zero_max_items() -> None:
     import pytest
 


### PR DESCRIPTION
## Summary

Fix #75: Add `run_id` keyword-only parameter to `dispatch_branch_name()` to prevent branch name collisions when the same issue is dispatched multiple times (Fix Loop retry scenario). The function now accepts `run_id` (default 0) and embeds it in the branch name as `feat/issue-{N}-run-{run_id}`. All existing callers are backward-compatible via the default value. Two new tests cover run_id embedding and default behavior.

Closes #75