### PR TITLE
feat(#79): Fix non-atomic Git config mutation in `configure_authenticated_origin()`: save extraheader before unsetting, restore it via try/except if `git remote set-url` fails, preventing permanent credential state corruption. Added 3 new tests (restore-on-failure, no-restore-when-empty, skip-no-token) and updated existing happy-path test to reflect the new `--get` pre-read step. All checks pass: ruff clean, format clean, mypy clean, 4/4 target tests green.

### DIFF
--- a/src/gearbox/core/gh.py
+++ b/src/gearbox/core/gh.py
@@ -645,27 +645,58 @@ def ensure_git_author() -> None:
 
 
 def configure_authenticated_origin(repo: str) -> None:
-    """Prefer GH_TOKEN for git push so checkout credentials do not shadow PAT scopes."""
+    """Prefer GH_TOKEN for git push so checkout credentials do not shadow PAT scopes.
+
+    The extraheader removal and origin URL update are performed atomically:
+    if ``set-url`` fails, the saved extraheader value is restored so the
+    repository's git credential state is not left broken.
+    """
     token = os.environ.get("GH_TOKEN")
     if not token:
         return
 
-    # actions/checkout injects an extraheader for github.token that overrides
-    # origin credentials. Remove it so PAT scopes on GH_TOKEN are honored.
-    subprocess.run(
-        ["git", "config", "--unset-all", "http.https://github.com/.extraheader"],
+    # Save the current extraheader so we can restore it on failure.
+    saved_header_result = subprocess.run(
+        ["git", "config", "--get", "http.https://github.com/.extraheader"],
+        capture_output=True,
+        text=True,
         check=False,
     )
-    subprocess.run(
-        [
-            "git",
-            "remote",
-            "set-url",
-            "origin",
-            f"https://x-access-token:{token}@github.com/{repo}.git",
-        ],
-        check=True,
+    saved_extraheader = (
+        saved_header_result.stdout.strip() if saved_header_result.returncode == 0 else None
     )
+
+    try:
+        # actions/checkout injects an extraheader for github.token that overrides
+        # origin credentials. Remove it so PAT scopes on GH_TOKEN are honored.
+        subprocess.run(
+            ["git", "config", "--unset-all", "http.https://github.com/.extraheader"],
+            check=False,
+        )
+        subprocess.run(
+            [
+                "git",
+                "remote",
+                "set-url",
+                "origin",
+                f"https://x-access-token:{token}@github.com/{repo}.git",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        # Restore the saved extraheader to avoid leaving git state broken.
+        if saved_extraheader:
+            subprocess.run(
+                [
+                    "git",
+                    "config",
+                    "--add",
+                    "http.https://github.com/.extraheader",
+                    saved_extraheader,
+                ],
+                check=False,
+            )
+        raise
 
 
 def _called_process_error_message(error: subprocess.CalledProcessError) -> str:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -101,6 +101,12 @@ class TestConfigureAuthenticatedOrigin:
             [
                 "git",
                 "config",
+                "--get",
+                "http.https://github.com/.extraheader",
+            ],
+            [
+                "git",
+                "config",
                 "--unset-all",
                 "http.https://github.com/.extraheader",
             ],
@@ -112,6 +118,73 @@ class TestConfigureAuthenticatedOrigin:
                 "https://x-access-token:pat-token@github.com/owner/repo.git",
             ],
         ]
+
+    def test_restores_extraheader_when_set_url_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If set-url fails, the extraheader must be restored to avoid breaking git state."""
+        commands: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs) -> MagicMock:
+            del kwargs
+            commands.append(cmd)
+            if cmd[0:4] == ["git", "remote", "set-url", "origin"]:
+                raise subprocess.CalledProcessError(1, cmd, stderr="fatal: not a git repository")
+            if cmd == ["git", "config", "--get", "http.https://github.com/.extraheader"]:
+                return MagicMock(returncode=0, stdout="AUTHORIZATION: basic xxx")
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setenv("GH_TOKEN", "pat-token")
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            configure_authenticated_origin("owner/repo")
+
+        # After failure, extraheader must be restored via --add
+        restore_cmd = [
+            "git",
+            "config",
+            "--add",
+            "http.https://github.com/.extraheader",
+            "AUTHORIZATION: basic xxx",
+        ]
+        assert restore_cmd in commands
+
+    def test_no_restore_when_extraheader_was_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """When no extraheader existed, no restore command should be issued on failure."""
+        commands: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs) -> MagicMock:
+            del kwargs
+            commands.append(cmd)
+            if cmd[0:4] == ["git", "remote", "set-url", "origin"]:
+                raise subprocess.CalledProcessError(1, cmd, stderr="error")
+            if cmd == ["git", "config", "--get", "http.https://github.com/.extraheader"]:
+                return MagicMock(returncode=1, stdout="")
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.setenv("GH_TOKEN", "pat-token")
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        with pytest.raises(subprocess.CalledProcessError):
+            configure_authenticated_origin("owner/repo")
+
+        # No --add restore when there was nothing to save
+        add_cmds = [c for c in commands if c[0:4] == ["git", "config", "--add"]]
+        assert len(add_cmds) == 0
+
+    def test_skips_when_no_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        commands: list[list[str]] = []
+
+        def fake_run(cmd: list[str], **kwargs) -> MagicMock:
+            del kwargs
+            commands.append(cmd)
+            return MagicMock(returncode=0, stdout="")
+
+        monkeypatch.delenv("GH_TOKEN", raising=False)
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        configure_authenticated_origin("owner/repo")
+
+        assert commands == []
 
 
 class TestAddIssueLabels:


### PR DESCRIPTION
## Summary

Fix non-atomic Git config mutation in `configure_authenticated_origin()`: save extraheader before unsetting, restore it via try/except if `git remote set-url` fails, preventing permanent credential state corruption. Added 3 new tests (restore-on-failure, no-restore-when-empty, skip-no-token) and updated existing happy-path test to reflect the new `--get` pre-read step. All checks pass: ruff clean, format clean, mypy clean, 4/4 target tests green.

Closes #79