### PR TITLE
feat(#80): Fix workflow job-level secret exposure: moved secrets from job-level `env:` to step-level `env:` with `::add-mask::` masking across 5 workflow files. Added `TestSecretScoping` test class that enforces no secrets at job-level env scope.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -111,10 +111,6 @@ jobs:
     needs: [plan, audit-run]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.repo != '' }}
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -130,7 +126,12 @@ jobs:
 
       - name: Aggregate audit results
         shell: bash
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: |
+          echo "::add-mask::$ANTHROPIC_AUTH_TOKEN"
           export PATH="$HOME/.local/bin:$PATH"
           echo "::group::[audit] downloaded run artifacts"
           find "$GITHUB_WORKSPACE/audit-runs" -maxdepth 2 -type f | sort || true
@@ -161,8 +162,6 @@ jobs:
       (github.event_name == 'schedule')
     needs: aggregate-audit
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -174,6 +173,8 @@ jobs:
           path: ./audit-output
 
       - name: Publish Issues
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         uses: ./actions/publish
         with:
           input_path: ./audit-output/issues.json

--- a/.github/workflows/backlog.yml
+++ b/.github/workflows/backlog.yml
@@ -152,11 +152,6 @@ jobs:
     needs: [plan, backlog-run]
     if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.repo != '' && needs.plan.outputs.issues != '' }}
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -172,7 +167,12 @@ jobs:
 
       - name: Aggregate backlog results
         shell: bash
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: |
+          echo "::add-mask::$ANTHROPIC_AUTH_TOKEN"
           export PATH="$HOME/.local/bin:$PATH"
           echo "::group::[backlog] downloaded run artifacts"
           find "$GITHUB_WORKSPACE/backlog-runs" -maxdepth 2 -type f | sort || true

--- a/.github/workflows/reusable-audit.yml
+++ b/.github/workflows/reusable-audit.yml
@@ -84,10 +84,6 @@ jobs:
     needs: [plan, audit-run]
     if: ${{ always() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -103,7 +99,12 @@ jobs:
 
       - name: Aggregate audit results
         shell: bash
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: |
+          echo "::add-mask::$ANTHROPIC_AUTH_TOKEN"
           export PATH="$HOME/.local/bin:$PATH"
           echo "::group::[audit] downloaded run artifacts"
           find "$GITHUB_WORKSPACE/audit-runs" -maxdepth 2 -type f | sort || true
@@ -132,8 +133,6 @@ jobs:
     if: inputs.create_issues
     needs: aggregate-audit
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -145,6 +144,8 @@ jobs:
           path: ./audit-output
 
       - name: Publish Issues
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
         uses: gqy20/gearbox/actions/publish@main
         with:
           input_path: ./audit-output/issues.json

--- a/.github/workflows/reusable-implement.yml
+++ b/.github/workflows/reusable-implement.yml
@@ -92,11 +92,6 @@ jobs:
     needs: [plan, implement-run]
     if: ${{ always() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
-      GH_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -112,7 +107,12 @@ jobs:
 
       - name: Aggregate implement results
         shell: bash
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: |
+          echo "::add-mask::$ANTHROPIC_AUTH_TOKEN"
           export PATH="$HOME/.local/bin:$PATH"
           CMD=(
             uv run --project "$GEARBOX_ACTION_ROOT" --directory "$GITHUB_WORKSPACE" gearbox agent implement-select

--- a/.github/workflows/reusable-review.yml
+++ b/.github/workflows/reusable-review.yml
@@ -77,11 +77,6 @@ jobs:
     needs: [plan, review-run]
     if: ${{ always() && needs.plan.result == 'success' }}
     runs-on: ubuntu-latest
-    env:
-      ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
-      ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
-      ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
-      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -97,7 +92,12 @@ jobs:
 
       - name: Aggregate review results
         shell: bash
+        env:
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+          ANTHROPIC_MODEL: ${{ secrets.ANTHROPIC_MODEL }}
         run: |
+          echo "::add-mask::$ANTHROPIC_AUTH_TOKEN"
           export PATH="$HOME/.local/bin:$PATH"
           CMD=(
             uv run --directory "$GEARBOX_ACTION_ROOT" gearbox agent review-select

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -328,3 +328,51 @@ class TestAutoMergeWorkflow:
         assert "skip_reason=" in workflow
         assert "::notice::" in workflow
         assert "::warning::" in workflow
+
+
+class TestSecretScoping:
+    """Secrets must not be exposed at job-level env; use step-level env + ::add-mask:: instead."""
+
+    _SECRET_ENV_LINE = re.compile(r"^\s+\w+:\s*\$\{\{\s*secrets\.\w+\s*\}\}")
+
+    def _workflow_files(self) -> list[Path]:
+        return sorted((_root() / ".github" / "workflows").glob("*.yml"))
+
+    def _find_job_level_secret_env(self, content: str) -> list[str]:
+        """Return (job_name, var_name) pairs for secrets inside job-level env: blocks."""
+        violations: list[str] = []
+        lines = content.split("\n")
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            # Job-level env: is indented 4 spaces (under jobs: → job-name)
+            if re.match(r"^    env:\s*$", line):
+                # Scan forward: 6-indented lines before steps: or another 4-indented key
+                job_name = "<unknown>"
+                for back in range(i - 1, max(i - 20, -1), -1):
+                    m = re.match(r"^  (\S+):\s*$", lines[back])
+                    if m:
+                        job_name = m.group(1)
+                        break
+                j = i + 1
+                while j < len(lines):
+                    sl = lines[j]
+                    if re.match(r"^      \w", sl) and not sl.strip().startswith("steps:"):
+                        if self._SECRET_ENV_LINE.search(sl):
+                            var = sl.split(":")[0].strip()
+                            violations.append(f"{job_name}.{var}")
+                        j += 1
+                    else:
+                        break
+            i += 1
+        return violations
+
+    def test_no_secrets_at_job_level_env(self) -> None:
+        """Job-level env: must never contain ${{ secrets.* }} references."""
+        for wf_path in self._workflow_files():
+            content = wf_path.read_text(encoding="utf-8")
+            violations = self._find_job_level_secret_env(content)
+            assert violations == [], (
+                f"{wf_path.name} has secrets at job-level env (should be step-level):\n"
+                + "\n".join(f"  {v}" for v in violations)
+            )


### PR DESCRIPTION
## Summary

Fix workflow job-level secret exposure: moved secrets from job-level `env:` to step-level `env:` with `::add-mask::` masking across 5 workflow files. Added `TestSecretScoping` test class that enforces no secrets at job-level env scope.

Closes #80