### PR TITLE
feat(#78): Added schema_version field (Literal["1.0"]) to all agent result Pydantic schemas via a new VersionedSchema base class. Implemented version validation in all load_*() functions (load_audit_result, load_review_result, load_implement_result, load_backlog_result) that raises clear ValueError on missing or mismatched versions. Added schema_version metadata to artifact writers (_write_audit_outputs issues.json, _cache_benchmarks). SDK parse_with_model tolerates missing schema_version (Pydantic supplies default). 26 new tests cover: schema presence on all 6 models, JSON schema inclusion, serialization, SDK parsing tolerance, version acceptance/rejection on all 4 load functions, and artifact metadata embedding.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -28,6 +28,7 @@ def _write_audit_outputs(result: AuditResult, output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     issues_payload = {
+        "schema_version": result.schema_version,
         "repo": result.repo,
         "profile": result.profile,
         "benchmarks": result.benchmarks,
@@ -72,11 +73,14 @@ def _get_cached_benchmarks(repo: str, language: str | None = None) -> list[str] 
 
 def _cache_benchmarks(repo: str, benchmarks: list[str]) -> None:
     """缓存对标仓库列表"""
+    from gearbox.agents.schemas import SCHEMA_VERSION
+
     cache_file = _BENCHMARK_CACHE_DIR / f"{repo.replace('/', '_')}.json"
     cache_file.parent.mkdir(parents=True, exist_ok=True)
     cache_file.write_text(
         json.dumps(
             {
+                "schema_version": SCHEMA_VERSION,
                 "benchmarks": benchmarks,
                 "cached_at": time.time(),
             }
@@ -86,6 +90,8 @@ def _cache_benchmarks(repo: str, benchmarks: list[str]) -> None:
 
 def load_audit_result(output_dir: Path) -> AuditResult:
     """从 audit 产物目录恢复 AuditResult。"""
+    from gearbox.agents.schemas import check_schema_version
+
     issues_path = output_dir / "issues.json"
     comparison_path = output_dir / "comparison.md"
 
@@ -93,6 +99,8 @@ def load_audit_result(output_dir: Path) -> AuditResult:
         raise FileNotFoundError(f"Missing audit artifact: {issues_path}")
 
     issues_payload = json.loads(issues_path.read_text(encoding="utf-8"))
+    check_schema_version(issues_payload, label=f"audit artifact ({issues_path})")
+
     comparison_markdown = (
         comparison_path.read_text(encoding="utf-8") if comparison_path.exists() else ""
     )

--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -73,11 +73,17 @@ def write_backlog_result(result: BacklogResult, output_path: Path) -> None:
 
 
 def load_backlog_result(path: Path) -> BacklogResult:
+    from gearbox.agents.schemas import check_schema_version
     from gearbox.agents.shared.artifacts import read_json_artifact
 
     data = read_json_artifact(path)
     raw_items = data.get("items", [])
     assert isinstance(raw_items, list)
+    for idx, item in enumerate(raw_items):
+        check_schema_version(
+            cast(dict[str, object], item),
+            label=f"backlog artifact ({path}) item[{idx}]",
+        )
     return BacklogResult(
         items=[
             BacklogItemResult.model_validate(item)

--- a/src/gearbox/agents/implement.py
+++ b/src/gearbox/agents/implement.py
@@ -20,9 +20,11 @@ def write_implement_result(result: ImplementResult, output_path: Path) -> None:
 
 def load_implement_result(path: Path) -> ImplementResult:
     """从 artifact 文件加载 Implement 结果"""
+    from gearbox.agents.schemas import check_schema_version
     from gearbox.agents.shared.artifacts import read_json_artifact
 
     data = read_json_artifact(path)
+    check_schema_version(data, label=f"implement artifact ({path})")
     return ImplementResult.model_validate(data)
 
 

--- a/src/gearbox/agents/review.py
+++ b/src/gearbox/agents/review.py
@@ -28,9 +28,11 @@ def write_review_result(result: ReviewResult, output_path: Path) -> None:
 
 
 def load_review_result(path: Path) -> ReviewResult:
+    from gearbox.agents.schemas import check_schema_version
     from gearbox.agents.shared.artifacts import read_json_artifact
 
     data = read_json_artifact(path)
+    check_schema_version(data, label=f"review artifact ({path})")
     return ReviewResult.model_validate(data)
 
 

--- a/src/gearbox/agents/schemas/__init__.py
+++ b/src/gearbox/agents/schemas/__init__.py
@@ -23,10 +23,34 @@ from pydantic import BaseModel, ValidationError
 
 from .audit import AuditResult, Issue
 from .backlog import BacklogItemResult
+from .base import SCHEMA_VERSION, VersionedSchema
 from .evaluator import EvaluationResult
 from .fix import FixResult
 from .implement import ImplementResult
 from .review import ReviewComment, ReviewResult
+
+
+def check_schema_version(data: dict[str, object], label: str = "artifact") -> None:
+    """Raise :class:`ValueError` if *data* lacks or mismatches ``schema_version``.
+
+    This is intended for **persisted artifacts** (files on disk).  Raw SDK
+    structured output that omits ``schema_version`` should *not* go through
+    this check — Pydantic will supply the default value instead.
+    """
+    version = data.get("schema_version")
+    if version is None:
+        raise ValueError(
+            f"{label} is missing schema_version field. "
+            f"The artifact may have been produced by an older version. "
+            f"Expected: {SCHEMA_VERSION!r}"
+        )
+    if version != SCHEMA_VERSION:
+        raise ValueError(
+            f"{label} has incompatible schema_version={version!r}. "
+            f"Expected: {SCHEMA_VERSION!r}. "
+            f"A migration path is required."
+        )
+
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +157,10 @@ __all__ = [
     "output_format_schema",
     "validate",
     "parse_with_model",
+    # Base
+    "SCHEMA_VERSION",
+    "VersionedSchema",
+    "check_schema_version",
     # Models
     "AuditResult",
     "Issue",

--- a/src/gearbox/agents/schemas/audit.py
+++ b/src/gearbox/agents/schemas/audit.py
@@ -6,6 +6,8 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from .base import VersionedSchema
+
 
 class Issue(BaseModel):
     title: str
@@ -13,7 +15,7 @@ class Issue(BaseModel):
     labels: str
 
 
-class AuditResult(BaseModel):
+class AuditResult(VersionedSchema):
     repo: str
     profile: dict[str, Any] = Field(default_factory=dict)
     comparison_markdown: str = ""

--- a/src/gearbox/agents/schemas/backlog.py
+++ b/src/gearbox/agents/schemas/backlog.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from .base import VersionedSchema
 
 
-class BacklogItemResult(BaseModel):
+class BacklogItemResult(VersionedSchema):
     labels: list[str] = Field(default_factory=list)
     priority: Literal["P0", "P1", "P2", "P3"] = "P3"
     complexity: Literal["S", "M", "L"] = "M"

--- a/src/gearbox/agents/schemas/base.py
+++ b/src/gearbox/agents/schemas/base.py
@@ -1,0 +1,26 @@
+"""Base schema with version identification for forward/backward compatibility.
+
+All agent result schemas inherit from :class:`VersionedSchema` so that every
+persisted artifact carries a ``schema_version`` field.  Load functions can
+then validate the version before calling ``model_validate()`` and raise a
+clear migration error when the version does not match.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# Current schema version — bump this when any result schema field is
+# added, removed, or has its type changed.
+SCHEMA_VERSION: Literal["1.0"] = "1.0"
+
+
+class VersionedSchema(BaseModel):
+    """Base class for all versioned agent-result schemas."""
+
+    schema_version: Literal["1.0"] = Field(
+        default=SCHEMA_VERSION,
+        description="Schema version for artifact compatibility checks",
+    )

--- a/src/gearbox/agents/schemas/evaluator.py
+++ b/src/gearbox/agents/schemas/evaluator.py
@@ -6,6 +6,8 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Field
 
+from .base import VersionedSchema
+
 
 def _coerce_score_keys(data: dict[str, Any]) -> dict[int, Any]:
     """Convert string keys to int, dropping non-numeric keys."""
@@ -29,7 +31,7 @@ ScoreDict = Annotated[
 ]
 
 
-class EvaluationResult(BaseModel):
+class EvaluationResult(VersionedSchema):
     winner: int = Field(ge=0, description="最佳结果索引 (0-based)")
     scores: ScoreDict = Field(default_factory=dict)
     reasoning: str = ""

--- a/src/gearbox/agents/schemas/fix.py
+++ b/src/gearbox/agents/schemas/fix.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from .base import VersionedSchema
 
 
-class FixResult(BaseModel):
+class FixResult(VersionedSchema):
     """Fix Agent 执行结果：根据 Review 反馈修补 PR。"""
 
     verdict: Literal["fixed", "partial", "skipped"] = Field(

--- a/src/gearbox/agents/schemas/implement.py
+++ b/src/gearbox/agents/schemas/implement.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from .base import VersionedSchema
 
 
-class ImplementResult(BaseModel):
+class ImplementResult(VersionedSchema):
     branch_name: str
     summary: str
     files_changed: list[str] = Field(default_factory=list)

--- a/src/gearbox/agents/schemas/review.py
+++ b/src/gearbox/agents/schemas/review.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from .base import VersionedSchema
+
 
 class ReviewComment(BaseModel):
     file: str
@@ -14,7 +16,7 @@ class ReviewComment(BaseModel):
     severity: Literal["blocker", "warning", "info"] = "info"
 
 
-class ReviewResult(BaseModel):
+class ReviewResult(VersionedSchema):
     verdict: Literal["LGTM", "Request Changes", "Comment Only"]
     score: int = Field(ge=0, le=10)
     summary: str

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -361,6 +361,7 @@ class TestAgentCommand:
                     {
                         "items": [
                             {
+                                "schema_version": "1.0",
                                 "issue_number": issue,
                                 "labels": ["enhancement"],
                                 "priority": "P2",
@@ -414,6 +415,7 @@ class TestAgentCommand:
                 {
                     "items": [
                         {
+                            "schema_version": "1.0",
                             "issue_number": 2,
                             "labels": ["enhancement"],
                             "priority": "P2",
@@ -494,6 +496,7 @@ class TestAgentCommand:
         (run_dir / "result.json").write_text(
             json.dumps(
                 {
+                    "schema_version": "1.0",
                     "verdict": "LGTM",
                     "score": 8,
                     "summary": "Looks good",

--- a/tests/test_schema_version.py
+++ b/tests/test_schema_version.py
@@ -1,0 +1,267 @@
+"""Tests for schema version identification and forward/backward compatibility."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from gearbox.agents.schemas import (
+    AuditResult,
+    BacklogItemResult,
+    EvaluationResult,
+    FixResult,
+    ImplementResult,
+    ReviewResult,
+    parse_with_model,
+)
+from gearbox.agents.schemas.audit import Issue as AuditIssue
+
+# ---------------------------------------------------------------------------
+# 1. All result schemas carry schema_version with correct default
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionFieldPresent:
+    """Every result model must expose a schema_version field defaulting to '1.0'."""
+
+    @pytest.mark.parametrize(
+        "model_cls, kwargs",
+        [
+            (AuditResult, {"repo": "o/r"}),
+            (ReviewResult, {"verdict": "LGTM", "score": 8, "summary": "ok"}),
+            (ImplementResult, {"branch_name": "f/x", "summary": "s"}),
+            (BacklogItemResult, {}),
+            (EvaluationResult, {"winner": 0}),
+            (FixResult, {"verdict": "skipped", "commits_pushed": 0}),
+        ],
+    )
+    def test_default_schema_version_is_1_0(self, model_cls, kwargs) -> None:
+        instance = model_cls(**kwargs)
+        assert instance.schema_version == "1.0"
+
+    @pytest.mark.parametrize(
+        "model_cls",
+        [
+            AuditResult,
+            ReviewResult,
+            ImplementResult,
+            BacklogItemResult,
+            EvaluationResult,
+            FixResult,
+        ],
+    )
+    def test_schema_version_field_in_json_schema(self, model_cls) -> None:
+        schema = model_cls.model_json_schema()
+        assert "schema_version" in schema["properties"]
+        assert "1.0" in schema["properties"]["schema_version"].get(
+            "const", schema["properties"]["schema_version"].get("enum", [])
+        )
+
+    def test_schema_version_serialises_to_json(self) -> None:
+        result = ImplementResult(branch_name="f/x", summary="s")
+        dumped = result.model_dump()
+        assert dumped["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# 2. parse_with_model tolerates missing schema_version (SDK output)
+# ---------------------------------------------------------------------------
+
+
+class TestParseWithModelVersionTolerance:
+    """Structured output from the SDK may omit schema_version; we must still parse it."""
+
+    def test_audit_parse_without_schema_version_succeeds(self) -> None:
+        from claude_agent_sdk import ResultMessage
+
+        msg = ResultMessage(
+            subtype="result",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            structured_output={
+                "repo": "owner/repo",
+                "profile": {},
+                "comparison_markdown": "",
+                "benchmarks": [],
+                "issues": [],
+            },
+        )
+        result = parse_with_model(msg, AuditResult)
+        assert result is not None
+        assert result.schema_version == "1.0"
+
+    def test_review_parse_without_schema_version_succeeds(self) -> None:
+        from claude_agent_sdk import ResultMessage
+
+        msg = ResultMessage(
+            subtype="result",
+            duration_ms=100,
+            duration_api_ms=80,
+            is_error=False,
+            num_turns=1,
+            session_id="s",
+            structured_output={
+                "verdict": "LGTM",
+                "score": 7,
+                "summary": "ok",
+                "comments": [],
+            },
+        )
+        result = parse_with_model(msg, ReviewResult)
+        assert result is not None
+        assert result.schema_version == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# 3. load_* functions validate version on persisted artifacts
+# ---------------------------------------------------------------------------
+
+
+class TestLoadAuditResultVersionCheck:
+    """load_audit_result must reject artifacts whose version does not match."""
+
+    def test_loads_current_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.audit import _write_audit_outputs, load_audit_result
+
+        result = AuditResult(repo="o/r", issues=[AuditIssue(title="T", body="B", labels="bug")])
+        _write_audit_outputs(result, tmp_path)
+
+        loaded = load_audit_result(tmp_path)
+        assert loaded.repo == "o/r"
+        assert loaded.schema_version == "1.0"
+
+    def test_rejects_missing_version_in_issues_json(self, tmp_path: Path) -> None:
+        from gearbox.agents.audit import load_audit_result
+
+        # Write a legacy (pre-version) issues.json
+        (tmp_path / "issues.json").write_text(
+            json.dumps(
+                {
+                    "repo": "o/r",
+                    "profile": {},
+                    "benchmarks": [],
+                    "issues": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "comparison.md").write_text("# old\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="schema_version"):
+            load_audit_result(tmp_path)
+
+    def test_rejects_wrong_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.audit import load_audit_result
+
+        (tmp_path / "issues.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": "2.0",
+                    "repo": "o/r",
+                    "profile": {},
+                    "benchmarks": [],
+                    "issues": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        (tmp_path / "comparison.md").write_text("# v2\n", encoding="utf-8")
+
+        with pytest.raises(ValueError, match="schema_version.*2.0.*1.0"):
+            load_audit_result(tmp_path)
+
+
+class TestLoadReviewResultVersionCheck:
+    def test_loads_current_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.review import load_review_result, write_review_result
+
+        result = ReviewResult(verdict="LGTM", score=8, summary="ok")
+        write_review_result(result, tmp_path / "result.json")
+        loaded = load_review_result(tmp_path / "result.json")
+        assert loaded.schema_version == "1.0"
+
+    def test_rejects_missing_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.review import load_review_result
+
+        (tmp_path / "result.json").write_text(
+            json.dumps({"verdict": "LGTM", "score": 8, "summary": "ok", "comments": []}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="schema_version"):
+            load_review_result(tmp_path / "result.json")
+
+
+class TestLoadImplementResultVersionCheck:
+    def test_loads_current_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.implement import load_implement_result, write_implement_result
+
+        result = ImplementResult(branch_name="f/x", summary="s")
+        write_implement_result(result, tmp_path / "result.json")
+        loaded = load_implement_result(tmp_path / "result.json")
+        assert loaded.schema_version == "1.0"
+
+    def test_rejects_missing_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.implement import load_implement_result
+
+        (tmp_path / "result.json").write_text(
+            json.dumps({"branch_name": "f/x", "summary": "s"}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="schema_version"):
+            load_implement_result(tmp_path / "result.json")
+
+
+class TestLoadBacklogResultVersionCheck:
+    def test_loads_current_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.backlog import BacklogResult, load_backlog_result, write_backlog_result
+
+        item = BacklogItemResult(labels=["bug"], priority="P1", complexity="S")
+        write_backlog_result(BacklogResult(items=[item]), tmp_path / "result.json")
+        loaded = load_backlog_result(tmp_path / "result.json")
+        assert loaded.items[0].schema_version == "1.0"
+
+    def test_rejects_missing_version_on_items(self, tmp_path: Path) -> None:
+        from gearbox.agents.backlog import load_backlog_result
+
+        (tmp_path / "result.json").write_text(
+            json.dumps({"items": [{"labels": ["bug"], "priority": "P1", "complexity": "S"}]}),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match="schema_version"):
+            load_backlog_result(tmp_path / "result.json")
+
+
+# ---------------------------------------------------------------------------
+# 4. Artifact writers embed version metadata
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactVersionMetadata:
+    def test_write_audit_outputs_includes_schema_version(self, tmp_path: Path) -> None:
+        from gearbox.agents.audit import _write_audit_outputs
+
+        result = AuditResult(repo="o/r", issues=[AuditIssue(title="T", body="B", labels="bug")])
+        _write_audit_outputs(result, tmp_path)
+
+        data = json.loads((tmp_path / "issues.json").read_text(encoding="utf-8"))
+        assert data.get("schema_version") == "1.0"
+
+    def test_benchmark_cache_includes_version_metadata(self, tmp_path, monkeypatch) -> None:
+        from gearbox.agents.audit import _cache_benchmarks, _get_cached_benchmarks
+
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr("gearbox.agents.audit._BENCHMARK_CACHE_DIR", cache_dir)
+
+        _cache_benchmarks("owner/repo", ["bench/a", "bench/b"])
+        cached = _get_cached_benchmarks("owner/repo")
+        assert cached == ["bench/a", "bench/b"]
+
+        cache_file = cache_dir / "owner_repo.json"
+        data = json.loads(cache_file.read_text(encoding="utf-8"))
+        assert data.get("schema_version") == "1.0"


### PR DESCRIPTION
## Summary

Added schema_version field (Literal["1.0"]) to all agent result Pydantic schemas via a new VersionedSchema base class. Implemented version validation in all load_*() functions (load_audit_result, load_review_result, load_implement_result, load_backlog_result) that raises clear ValueError on missing or mismatched versions. Added schema_version metadata to artifact writers (_write_audit_outputs issues.json, _cache_benchmarks). SDK parse_with_model tolerates missing schema_version (Pydantic supplies default). 26 new tests cover: schema presence on all 6 models, JSON schema inclusion, serialization, SDK parsing tolerance, version acceptance/rejection on all 4 load functions, and artifact metadata embedding.

Closes #78