### PR TITLE
feat(#86): Implement ValidationError → LLM feedback retry mechanism for agent structured output parsing. Added `query_structured_with_retry()` in `structured.py` that catches `ValidationError` (or None result) from `parse_with_model()`, extracts human-readable error details, constructs a feedback prompt with validation errors, and retries up to 2 times with remaining turns. Integrated into all 6 agents: audit, review, implement, fix, evaluator, backlog. 5 new tests cover happy path, retry-on-error success, retry exhaustion, default max_retries, and None-output retry. All 259 tests pass, ruff and mypy clean.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -202,12 +202,13 @@ async def run_audit(
         query,
     )
 
-    from gearbox.agents.schemas import output_format_schema, parse_with_model
+    from gearbox.agents.schemas import output_format_schema
     from gearbox.agents.shared.runtime import prepare_agent_options
     from gearbox.agents.shared.scanner import (
         format_scan_summary,
         scan_repository,
     )
+    from gearbox.agents.shared.structured import query_structured_with_retry
     from gearbox.config import get_anthropic_base_url, get_anthropic_model
 
     resolved_model = model or get_anthropic_model()
@@ -322,23 +323,26 @@ async def run_audit(
 
 请返回完整的结构化审计结果。"""
 
-        structured: AuditResult | None = None
+        from claude_agent_sdk import query
+
         total_cost: float | None = None
 
+        def _extract_cost(message: object) -> None:
+            nonlocal total_cost
+            total_cost = getattr(message, "total_cost_usd", total_cost)
+
         try:
-            async for message in query(prompt=prompt, options=options):
-                sdk_logger.handle_message(message, echo_assistant_text=False)
-                total_cost = getattr(message, "total_cost_usd", total_cost)
-                if structured is None:
-                    parsed = parse_with_model(message, AuditResult)
-                    if parsed is not None:
-                        structured = parsed
-                        break
+            structured = await query_structured_with_retry(
+                query_fn=query,
+                options=options,
+                prompt=prompt,
+                model_class=AuditResult,
+                sdk_logger=sdk_logger,
+                per_message_callback=_extract_cost,
+            )
         finally:
             sdk_logger.log_completion()
 
-        if structured is None:
-            raise RuntimeError("Audit agent did not return structured output")
         structured.cost = total_cost
 
         if structured.benchmarks and not benchmarks:

--- a/src/gearbox/agents/backlog.py
+++ b/src/gearbox/agents/backlog.py
@@ -174,10 +174,11 @@ async def run_backlog_item(
 
     from claude_agent_sdk import ClaudeAgentOptions, query
 
-    from gearbox.agents.schemas import output_format_schema, parse_with_model
+    from gearbox.agents.schemas import output_format_schema
     from gearbox.agents.shared import clone_repository
     from gearbox.agents.shared.prompt_helpers import format_issues_summary
     from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.structured import query_structured_with_retry
     from gearbox.core.gh import list_open_issues
 
     issue = _gh_issue_view(repo, issue_number)
@@ -230,24 +231,19 @@ async def run_backlog_item(
         cwd=str(cwd),
     )
 
-    structured: BacklogItemResult | None = None
-
     try:
-        async for message in query(prompt=prompt, options=options):
-            sdk_logger.handle_message(message, echo_assistant_text=False)
-            if structured is None:
-                parsed = parse_with_model(message, BacklogItemResult)
-                if parsed is not None:
-                    structured = parsed
-                    # Inject issue_number since it's not part of the schema output
-                    structured.issue_number = issue_number
-                    break
+        structured = await query_structured_with_retry(
+            query_fn=query,
+            options=options,
+            prompt=prompt,
+            model_class=BacklogItemResult,
+            sdk_logger=sdk_logger,
+        )
+        # Inject issue_number since it's not part of the schema output
+        structured.issue_number = issue_number
     finally:
         sdk_logger.log_completion()
         if clone_dir is not None:
             clone_dir.cleanup()
-
-    if structured is None:
-        raise RuntimeError("Backlog agent did not return structured output")
 
     return structured

--- a/src/gearbox/agents/evaluator.py
+++ b/src/gearbox/agents/evaluator.py
@@ -116,8 +116,9 @@ async def run_evaluator(
         query,
     )
 
-    from gearbox.agents.schemas import output_format_schema, parse_with_model
+    from gearbox.agents.schemas import output_format_schema
     from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.structured import query_structured_with_retry
     from gearbox.config import get_anthropic_model
 
     model = model or get_anthropic_model()
@@ -140,20 +141,15 @@ async def run_evaluator(
         cwd="(sdk default)",
     )
 
-    structured: EvaluationResult | None = None
-
     try:
-        async for message in query(prompt=prompt, options=options):
-            sdk_logger.handle_message(message, echo_assistant_text=False)
-            if structured is None:
-                parsed = parse_with_model(message, EvaluationResult)
-                if parsed is not None:
-                    structured = parsed
-                    break
+        structured = await query_structured_with_retry(
+            query_fn=query,
+            options=options,
+            prompt=prompt,
+            model_class=EvaluationResult,
+            sdk_logger=sdk_logger,
+        )
     finally:
         sdk_logger.log_completion()
-
-    if structured is None:
-        raise RuntimeError("Evaluator agent did not return structured output")
 
     return structured

--- a/src/gearbox/agents/fix.py
+++ b/src/gearbox/agents/fix.py
@@ -6,7 +6,8 @@ from pathlib import Path
 from typing import Any
 
 from gearbox.agents.schemas import FixResult as _FixResultModel
-from gearbox.agents.schemas import output_format_schema, parse_with_model
+from gearbox.agents.schemas import output_format_schema
+from gearbox.agents.shared.structured import query_structured_with_retry
 
 FixResult = _FixResultModel
 
@@ -141,20 +142,15 @@ async def run_fix(
         cwd=str(Path.cwd()),
     )
 
-    structured: FixResult | None = None
-
     try:
-        async for message in query(prompt=prompt, options=options):
-            sdk_logger.handle_message(message, echo_assistant_text=False)
-            if structured is None:
-                parsed = parse_with_model(message, FixResult)
-                if parsed is not None:
-                    structured = parsed
-                    break
+        structured = await query_structured_with_retry(
+            query_fn=query,
+            options=options,
+            prompt=prompt,
+            model_class=FixResult,
+            sdk_logger=sdk_logger,
+        )
     finally:
         sdk_logger.log_completion()
-
-    if structured is None:
-        raise RuntimeError("Fix agent did not return structured output")
 
     return structured

--- a/src/gearbox/agents/implement.py
+++ b/src/gearbox/agents/implement.py
@@ -133,8 +133,9 @@ async def run_implement(
 
     from claude_agent_sdk import ClaudeAgentOptions, query
 
-    from gearbox.agents.schemas import output_format_schema, parse_with_model
+    from gearbox.agents.schemas import output_format_schema
     from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.structured import query_structured_with_retry
 
     project_root = Path.cwd()
     issue = _gh_issue_view(repo, issue_number)
@@ -172,20 +173,15 @@ async def run_implement(
         cwd=str(project_root),
     )
 
-    structured: ImplementResult | None = None
-
     try:
-        async for message in query(prompt=prompt, options=options):
-            sdk_logger.handle_message(message, echo_assistant_text=False)
-            if structured is None:
-                parsed = parse_with_model(message, ImplementResult)
-                if parsed is not None:
-                    structured = parsed
-                    break
+        structured = await query_structured_with_retry(
+            query_fn=query,
+            options=options,
+            prompt=prompt,
+            model_class=ImplementResult,
+            sdk_logger=sdk_logger,
+        )
     finally:
         sdk_logger.log_completion()
-
-    if structured is None:
-        raise RuntimeError("Implement agent did not return structured output")
 
     return structured

--- a/src/gearbox/agents/review.py
+++ b/src/gearbox/agents/review.py
@@ -122,8 +122,9 @@ async def run_review(
 
     from claude_agent_sdk import ClaudeAgentOptions, query
 
-    from gearbox.agents.schemas import output_format_schema, parse_with_model
+    from gearbox.agents.schemas import output_format_schema
     from gearbox.agents.shared.runtime import prepare_agent_options
+    from gearbox.agents.shared.structured import query_structured_with_retry
 
     project_root = Path(__file__).resolve().parents[3]
     pr_info = _gh_pr_view(repo, pr_number)
@@ -167,20 +168,15 @@ async def run_review(
         cwd=str(project_root),
     )
 
-    structured: ReviewResult | None = None
-
     try:
-        async for message in query(prompt=prompt, options=options):
-            sdk_logger.handle_message(message, echo_assistant_text=False)
-            if structured is None:
-                parsed = parse_with_model(message, ReviewResult)
-                if parsed is not None:
-                    structured = parsed
-                    break
+        structured = await query_structured_with_retry(
+            query_fn=query,
+            options=options,
+            prompt=prompt,
+            model_class=ReviewResult,
+            sdk_logger=sdk_logger,
+        )
     finally:
         sdk_logger.log_completion()
-
-    if structured is None:
-        raise RuntimeError("Review agent did not return structured output")
 
     return structured

--- a/src/gearbox/agents/shared/structured.py
+++ b/src/gearbox/agents/shared/structured.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, AsyncIterator, Callable, TypeVar, cast
 
-from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
+from claude_agent_sdk import AssistantMessage, ClaudeAgentOptions, ResultMessage, ToolUseBlock
 from pydantic import ValidationError
 
 logger = logging.getLogger(__name__)
@@ -63,3 +63,100 @@ def _extract_raw_dict(message: object) -> dict[str, Any] | None:
                 return block.input
 
     return None
+
+
+def _format_validation_error(error: ValidationError) -> str:
+    """Extract human-readable error details from a Pydantic ValidationError."""
+    parts: list[str] = []
+    for err in error.errors():
+        loc = " → ".join(str(x) for x in err["loc"])
+        msg = err["msg"]
+        inp = err.get("input")
+        input_str = repr(inp) if inp is not None else ""
+        parts.append(f"  - 字段 [{loc}]: {msg} (输入值: {input_str})")
+    return "\n".join(parts)
+
+
+async def query_structured_with_retry(
+    query_fn: Callable[..., AsyncIterator],
+    options: ClaudeAgentOptions,
+    prompt: str,
+    model_class: type[T],
+    sdk_logger: Any,
+    max_retries: int = 2,
+    per_message_callback: Callable[[object], None] | None = None,
+) -> T:
+    """Call LLM query and parse structured output with ValidationError retry.
+
+    Wraps the common ``async for message in query(...)`` + ``parse_with_model()``
+    loop used by every agent (audit / review / implement / …).  When
+    ``parse_with_model`` raises **ValidationError** or returns **None**, a
+    feedback prompt containing the validation error details is sent to the LLM
+    so it can correct its output.
+
+    Args:
+        query_fn: The async generator callable (typically :func:`claude_agent_sdk.query`).
+        options: SDK agent options.
+        prompt: User prompt for the first attempt.
+        model_class: Pydantic model class for structured output validation.
+        sdk_logger: SdkEventLogger instance for lifecycle logging.
+        max_retries: Maximum number of retries after the initial attempt (default 2).
+        per_message_callback: Optional callback invoked on every SDK message
+            before parsing (useful for extracting side-channel data like cost).
+
+    Returns:
+        Validated parsed instance of *model_class*.
+
+    Raises:
+        RuntimeError: If no valid structured output is obtained after all attempts.
+    """
+    current_prompt = prompt
+    last_error: ValidationError | None = None
+
+    for attempt in range(max_retries + 1):  # initial + up to max_retries
+        try:
+            async for message in query_fn(prompt=current_prompt, options=options):
+                sdk_logger.handle_message(message, echo_assistant_text=False)
+                if per_message_callback is not None:
+                    per_message_callback(message)
+                try:
+                    parsed = parse_with_model(message, model_class)
+                    if parsed is not None:
+                        return parsed
+                except ValidationError as e:
+                    last_error = e
+                    logger.warning(
+                        "Attempt %d/%d: structured output validation failed: %s",
+                        attempt + 1,
+                        max_retries + 1,
+                        _format_validation_error(e),
+                    )
+        except ValidationError as e:
+            last_error = e
+            logger.warning(
+                "Attempt %d/%d: structured output validation failed: %s",
+                attempt + 1,
+                max_retries + 1,
+                _format_validation_error(e),
+            )
+
+        # Prepare feedback prompt for retry
+        if attempt < max_retries:
+            error_details = _format_validation_error(last_error) if last_error else "未知错误"
+            current_prompt = f"""{prompt}
+
+---
+
+**⚠️ 上次输出的结构化数据校验失败，请修正后重新输出：**
+
+{error_details}
+
+请确保输出完全符合 JSON Schema 要求，修正上述字段后重新返回完整的结构化结果。"""
+            logger.info("Retrying structured output (attempt %d/%d)", attempt + 2, max_retries + 1)
+
+    # All attempts exhausted
+    error_summary = _format_validation_error(last_error) if last_error else "无结构化输出"
+    raise RuntimeError(
+        f"{model_class.__name__} agent did not return valid structured output "
+        f"after {max_retries + 1} attempts. Last error:\n{error_summary}"
+    )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -477,3 +477,187 @@ class TestStructuredOutputErrorPaths:
     def test_legacy_parse_structured_output_string(self) -> None:
         result = parse_structured_output(self._result("not a dict"), lambda data: data["key"])
         assert result is None
+
+
+class TestQueryStructuredWithRetry:
+    """Test ValidationError → LLM feedback retry mechanism."""
+
+    @staticmethod
+    def _make_options():
+        from claude_agent_sdk import ClaudeAgentOptions
+
+        return ClaudeAgentOptions(
+            model="test-model",
+            max_turns=10,
+            output_format={"type": "json_schema", "schema": {}, "name": "Test", "strict": True},
+        )
+
+    @staticmethod
+    def _make_logger():
+        class FakeLogger:
+            def log_start(self, **kwargs):
+                pass
+
+            def handle_message(self, *args, **kwargs):
+                pass
+
+            def log_completion(self):
+                pass
+
+        return FakeLogger()
+
+    def test_succeeds_on_first_attempt(self) -> None:
+        """Happy path: first query returns valid structured output."""
+        import asyncio
+
+        from gearbox.agents.shared.structured import query_structured_with_retry
+
+        good_data = {
+            "repo": "owner/repo",
+            "profile": {"language": "python"},
+            "comparison_markdown": "# Test",
+            "benchmarks": [],
+            "issues": [],
+        }
+
+        async def fake_query(**kwargs):
+            del kwargs
+            yield _result_message(good_data)
+
+        result = asyncio.run(
+            query_structured_with_retry(
+                query_fn=fake_query,
+                options=self._make_options(),
+                prompt="audit this repo",
+                model_class=AuditResult,
+                sdk_logger=self._make_logger(),
+            )
+        )
+        assert result is not None
+        assert result.repo == "owner/repo"
+
+    def test_retries_on_validation_error_and_succeeds(self) -> None:
+        """ValidationError on first attempt triggers retry with feedback prompt."""
+        import asyncio
+
+        from gearbox.agents.shared.structured import query_structured_with_retry
+
+        # repo must be str; int will cause ValidationError
+        bad_data = {"repo": 123, "profile": {}}
+        good_data = {
+            "repo": "owner/repo",
+            "profile": {"language": "python"},
+            "comparison_markdown": "# Test",
+            "benchmarks": [],
+            "issues": [],
+        }
+        call_count = 0
+
+        async def fake_query(prompt=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            del kwargs
+            if call_count == 1:
+                yield _result_message(bad_data)
+            else:
+                # Verify retry prompt contains error details
+                assert prompt is not None
+                assert "校验失败" in prompt or "validation" in prompt.lower()
+                yield _result_message(good_data)
+
+        result = asyncio.run(
+            query_structured_with_retry(
+                query_fn=fake_query,
+                options=self._make_options(),
+                prompt="audit this repo",
+                model_class=AuditResult,
+                sdk_logger=self._make_logger(),
+            )
+        )
+        assert result is not None
+        assert result.repo == "owner/repo"
+        assert call_count == 2
+
+    def test_exhausts_retries_and_raises_runtime_error(self) -> None:
+        """After max retries, raises RuntimeError with failure info."""
+        import asyncio
+
+        from gearbox.agents.shared.structured import query_structured_with_retry
+
+        bad_data = {"repo": 123}  # invalid: repo should be str
+        call_count = 0
+
+        async def fake_query(prompt=None, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            del kwargs
+            yield _result_message(bad_data)
+
+        with pytest.raises(RuntimeError, match="did not return valid structured output"):
+            asyncio.run(
+                query_structured_with_retry(
+                    query_fn=fake_query,
+                    options=self._make_options(),
+                    prompt="audit this repo",
+                    model_class=AuditResult,
+                    sdk_logger=self._make_logger(),
+                    max_retries=2,
+                )
+            )
+        # Initial attempt + 2 retries = 3 calls
+        assert call_count == 3
+
+    def test_default_max_retries_is_two(self) -> None:
+        """Default max_retries should be 2."""
+        import inspect
+
+        from gearbox.agents.shared.structured import query_structured_with_retry
+
+        sig = inspect.signature(query_structured_with_retry)
+        default = sig.parameters["max_retries"].default
+        assert default == 2
+
+    def test_none_structured_output_triggers_retry(self) -> None:
+        """None structured output (no parseable data) also triggers retry."""
+        import asyncio
+
+        from gearbox.agents.shared.structured import query_structured_with_retry
+
+        good_data = {
+            "repo": "owner/repo",
+            "profile": {},
+            "comparison_markdown": "",
+            "benchmarks": [],
+            "issues": [],
+        }
+        call_count = 0
+
+        async def fake_query(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            del kwargs
+            if call_count == 1:
+                # Return message with no structured output (e.g., text-only response)
+                yield ResultMessage(
+                    subtype="result",
+                    duration_ms=100,
+                    duration_api_ms=80,
+                    is_error=False,
+                    num_turns=1,
+                    session_id="session",
+                    structured_output=None,
+                )
+            else:
+                yield _result_message(good_data)
+
+        result = asyncio.run(
+            query_structured_with_retry(
+                query_fn=fake_query,
+                options=self._make_options(),
+                prompt="audit this repo",
+                model_class=AuditResult,
+                sdk_logger=self._make_logger(),
+            )
+        )
+        assert result is not None
+        assert call_count == 2

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -479,7 +479,7 @@ class TestFixAgent:
 
         import asyncio
 
-        with pytest.raises(RuntimeError, match="did not return structured output"):
+        with pytest.raises(RuntimeError, match="did not return valid structured output"):
             asyncio.run(run_fix("o/r", 1))
 
 


### PR DESCRIPTION
## Summary

Implement ValidationError → LLM feedback retry mechanism for agent structured output parsing. Added `query_structured_with_retry()` in `structured.py` that catches `ValidationError` (or None result) from `parse_with_model()`, extracts human-readable error details, constructs a feedback prompt with validation errors, and retries up to 2 times with remaining turns. Integrated into all 6 agents: audit, review, implement, fix, evaluator, backlog. 5 new tests cover happy path, retry-on-error success, retry exhaustion, default max_retries, and None-output retry. All 259 tests pass, ruff and mypy clean.

Closes #86