### PR TITLE
feat(#91): Fix #91: Add timeout protection to clone_repository() (600s) and scan_repository() per-future result() (300s). Both now raise/record clear timeout errors instead of hanging indefinitely on large repos or slow scanners.

### DIFF
--- a/src/gearbox/agents/shared/git.py
+++ b/src/gearbox/agents/shared/git.py
@@ -5,14 +5,20 @@ import tempfile
 from pathlib import Path
 
 
-def clone_repository(repo: str) -> tuple[Path, tempfile.TemporaryDirectory[str]]:
+def clone_repository(
+    repo: str, timeout: int = 600
+) -> tuple[Path, tempfile.TemporaryDirectory[str]]:
     """将目标仓库克隆到临时目录，供扫描和 Agent 分析统一使用。
 
     Args:
         repo: 仓库标识（owner/name 或本地 git 仓库路径）
+        timeout: 克隆超时秒数，默认 600 秒（10 分钟）
 
     Returns:
         (clone_root, temp_dir) — clone_root 是仓库根目录，temp_dir 需在用完后 cleanup
+
+    Raises:
+        RuntimeError: 克隆失败或超时时抛出
     """
     temp_dir = tempfile.TemporaryDirectory(prefix="gearbox-clone-")
     clone_root = Path(temp_dir.name) / "repo"
@@ -23,7 +29,12 @@ def clone_repository(repo: str) -> tuple[Path, tempfile.TemporaryDirectory[str]]
     else:
         cmd = ["gh", "repo", "clone", repo, str(clone_root), "--", "--depth", "1"]
 
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        temp_dir.cleanup()
+        raise RuntimeError(f"clone timed out after {timeout}s for {repo}") from None
+
     if result.returncode != 0:
         temp_dir.cleanup()
         stderr = result.stderr.strip() or result.stdout.strip() or "unknown clone error"

--- a/src/gearbox/agents/shared/scanner.py
+++ b/src/gearbox/agents/shared/scanner.py
@@ -346,7 +346,7 @@ def scan_repository(repo_path: Path) -> RepoScanResult:
             for future in concurrent.futures.as_completed(future_to_tool):
                 tool_name = future_to_tool[future]
                 try:
-                    result_data, status = future.result()
+                    result_data, status = future.result(timeout=300)
                     result.tool_statuses[tool_name] = status
                     if tool_name == "deptry":
                         result.deptry_issues = result_data
@@ -360,6 +360,8 @@ def scan_repository(repo_path: Path) -> RepoScanResult:
                     elif tool_name == "govulncheck":
                         result.govulncheck_vulns = result_data
                         result.govulncheck_scanned = True
+                except concurrent.futures.TimeoutError:
+                    result.tool_statuses[tool_name] = "timeout"
                 except Exception as exc:
                     result.tool_statuses[tool_name] = f"exception:{exc}"
 

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,49 @@
+"""测试 agents/shared/git.py 克隆操作"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gearbox.agents.shared.git import clone_repository
+
+
+class TestCloneRepositoryTimeout:
+    """clone_repository() 超时保护 (Issue #91)"""
+
+    def test_clone_timeout_raises_runtime_error(self, tmp_path: Path) -> None:
+        """超时时应抛出包含 'timeout' 的 RuntimeError"""
+        fake_repo = str(tmp_path / "fake-local-repo")
+        Path(fake_repo).mkdir()
+
+        def slow_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=kwargs.get("cmd", ["git"]), timeout=600)
+
+        with patch("gearbox.agents.shared.git.subprocess.run", side_effect=slow_run):
+            with pytest.raises(RuntimeError, match="timeout"):
+                clone_repository(fake_repo)
+
+    def test_clone_timeout_default_is_600_seconds(self) -> None:
+        """默认超时应为 600 秒（10 分钟）"""
+        import inspect
+
+        sig = inspect.signature(clone_repository)
+        assert "timeout" in sig.parameters
+        default = sig.parameters["timeout"].default
+        assert default == 600
+
+    def test_clone_custom_timeout_passed_to_subprocess(self, tmp_path: Path) -> None:
+        """自定义 timeout 值应传递给 subprocess.run"""
+        fake_repo = str(tmp_path / "local-repo")
+        Path(fake_repo).mkdir()
+        captured_kwargs: dict = {}
+
+        def capture_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+        with patch("gearbox.agents.shared.git.subprocess.run", side_effect=capture_run):
+            clone_repository(fake_repo, timeout=120)
+
+        assert captured_kwargs.get("timeout") == 120

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -410,6 +410,66 @@ class TestScanRepositoryOrchestration:
 
 
 # ---------------------------------------------------------------------------
+# scan_repository 超时保护 (Issue #91)
+# ---------------------------------------------------------------------------
+
+
+class TestScanRepositoryTimeout:
+    """scan_repository() per-future 超时保护 (Issue #91)"""
+
+    def test_future_timeout_recorded_in_tool_statuses(self, tmp_path: Path) -> None:
+        """future.result() 超时时应将 'timeout' 记录到 tool_statuses，不影响其他工具结果"""
+        import concurrent.futures
+
+        original_result = concurrent.futures.Future.result
+
+        def patched_result(self, timeout=None):
+            if timeout is not None:
+                raise concurrent.futures.TimeoutError()
+            return original_result(self)
+
+        with (
+            patch(
+                "gearbox.agents.shared.scanner.detect_project_type",
+                return_value=("python", "pip", False, False),
+            ),
+            patch("gearbox.agents.shared.scanner.run_cloc", return_value=({}, "ok")),
+            patch("gearbox.agents.shared.scanner.run_deptry", return_value=([], "ok")),
+            patch("gearbox.agents.shared.scanner.run_trivy", return_value=([], "ok")),
+            patch("gearbox.agents.shared.scanner.run_semgrep", return_value=([], "ok")),
+            patch.object(concurrent.futures.Future, "result", patched_result),
+        ):
+            actual = scan_repository(tmp_path)
+
+        # 至少有一个工具因超时被标记（所有 4 个并行任务都会超时）
+        timeout_tools = [k for k, v in actual.tool_statuses.items() if "timeout" in v.lower()]
+        assert len(timeout_tools) >= 1
+
+    def test_timeout_does_not_crash_scan_repository(self, tmp_path: Path) -> None:
+        """即使所有并行任务都超时，scan_repository 也应正常返回（不抛异常）"""
+        import concurrent.futures
+
+        def always_timeout(self, timeout=None):
+            if timeout is not None:
+                raise concurrent.futures.TimeoutError()
+            return ([], "ok")
+
+        with (
+            patch(
+                "gearbox.agents.shared.scanner.detect_project_type",
+                return_value=("python", "pip", False, False),
+            ),
+            patch("gearbox.agents.shared.scanner.run_cloc", return_value=({}, "ok")),
+            patch.object(concurrent.futures.Future, "result", always_timeout),
+        ):
+            actual = scan_repository(tmp_path)
+
+        # 应正常返回，tool_statuses 中应有 timeout 标记
+        assert isinstance(actual, RepoScanResult)
+        assert any("timeout" in v.lower() for v in actual.tool_statuses.values())
+
+
+# ---------------------------------------------------------------------------
 # format_scan_summary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fix #91: Add timeout protection to clone_repository() (600s) and scan_repository() per-future result() (300s). Both now raise/record clear timeout errors instead of hanging indefinitely on large repos or slow scanners.

Closes #91