### PR TITLE
feat(#92): Fix #92: Propagate scan failure info to agent prompt and AuditResult.failure_reason instead of silently continuing with no scan context.

Changes in `src/gearbox/agents/audit.py`:
1. Track `scan_failure_reason` when `scan_repository()` raises (line 220, 254)
2. Inject scan failure warning into the agent prompt so it knows scanning didn't complete and can annotate `failure_reason` (lines 280-284)
3. Auto-set `structured.failure_reason` with scan error details if the agent didn't set it (lines 351-355)

Tests in `tests/test_audit.py`:
- `test_scan_failure_injected_into_prompt`: Verifies the resolved system_prompt contains "扫描未完成" when scan fails
- `test_scan_failure_sets_failure_reason_on_result`: Verifies `failure_reason` is non-None and contains scan-related text when scan fails

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -217,6 +217,7 @@ async def run_audit(
     clone_dir: tempfile.TemporaryDirectory[str] | None = None
     scan_result = None
     scan_summary = ""
+    scan_failure_reason: str | None = None
 
     try:
         click.echo(f"📥 克隆目标仓库: {repo}")
@@ -250,6 +251,7 @@ async def run_audit(
                     f"🛡️ Go 漏洞: {len(scan_result.govulncheck_vulns)}"
                 )
             except Exception as e:
+                scan_failure_reason = str(e)
                 click.echo(f"⚠️ 扫描失败: {e}", err=True)
 
         if not benchmarks:
@@ -275,6 +277,11 @@ async def run_audit(
         prompt_parts = []
         if scan_summary and enable_prescan:
             prompt_parts.append(f"```json\n{scan_summary}\n```")
+        elif scan_failure_reason and enable_prescan:
+            prompt_parts.append(
+                f"> ⚠️ **扫描未完成**: 静态分析扫描失败 ({scan_failure_reason})。\n"
+                f"> 以下审计结果**缺乏扫描数据支撑**，请在 `failure_reason` 中标注此情况。"
+            )
         prompt_parts.append(existing_issues_str)
 
         if prompt_parts:
@@ -340,6 +347,12 @@ async def run_audit(
         if structured is None:
             raise RuntimeError("Audit agent did not return structured output")
         structured.cost = total_cost
+
+        # Propagate scan failure to result so downstream can detect incomplete audits
+        if scan_failure_reason and not structured.failure_reason:
+            structured.failure_reason = (
+                f"扫描未完成: {scan_failure_reason}。审计结果缺乏静态分析数据支撑。"
+            )
 
         if structured.benchmarks and not benchmarks:
             _cache_benchmarks(repo, structured.benchmarks)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -3,7 +3,10 @@
 import json
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock
 
+from gearbox.agents.audit import run_audit
+from gearbox.agents.schemas import AuditResult
 from gearbox.agents.shared import clone_repository, scanner
 from gearbox.agents.shared.scanner import scan_repository
 
@@ -120,3 +123,154 @@ dev = ["pytest"]
     assert "--known-first-party" in captured_cmd
     assert "demo_package" in captured_cmd
     assert "--optional-dependencies-dev-groups" in captured_cmd
+
+
+class TestScanFailureHandling:
+    """Verify that scan failures are propagated to the agent prompt and result."""
+
+    @staticmethod
+    def _make_tmp_repo(tmp_path: Path) -> str:
+        """Create a minimal git repo for testing."""
+        repo = tmp_path / "source"
+        repo.mkdir()
+        subprocess.run(["git", "init"], cwd=repo, check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        (repo / "README.md").write_text("hello\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "add", "README.md"], cwd=repo, check=True, capture_output=True, text=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return str(repo)
+
+    @staticmethod
+    def _mock_sdk(monkeypatch, fake_structured: AuditResult) -> MagicMock:
+        """Mock all SDK dependencies needed for run_audit()."""
+        captured_system_prompt: list[str] = []
+
+        async def fake_query(*args, **kwargs):
+            class FakeMsg:
+                pass
+
+            msg = FakeMsg()
+            msg.total_cost_usd = 0.001
+            yield msg
+
+        monkeypatch.setattr("claude_agent_sdk.query", fake_query)
+        monkeypatch.setattr("gearbox.config.get_anthropic_model", lambda: "test-model")
+        monkeypatch.setattr("gearbox.config.get_anthropic_base_url", lambda: None)
+
+        fake_logger = MagicMock()
+        fake_logger.log_start = MagicMock()
+        fake_logger.handle_message = MagicMock(return_value=fake_structured)
+        fake_logger.log_completion = MagicMock()
+
+        def fake_prepare(opts, agent_name):
+            del agent_name
+            # Capture the actual system_prompt from the options passed in
+            captured_system_prompt.append(opts.system_prompt)
+            return opts, fake_logger
+
+        monkeypatch.setattr(
+            "gearbox.agents.shared.runtime.prepare_agent_options",
+            fake_prepare,
+        )
+        # parse_with_model is called inside run_audit() to extract structured output
+        monkeypatch.setattr(
+            "gearbox.agents.schemas.parse_with_model",
+            lambda msg, cls: fake_structured,
+        )
+
+        # Return captured so caller can inspect the system_prompt
+        mock_ctx = MagicMock()
+        mock_ctx.captured_system_prompt = captured_system_prompt
+        return mock_ctx
+
+    def test_scan_failure_injected_into_prompt(self, tmp_path: Path, monkeypatch) -> None:
+        """When scan_repository raises, the resolved prompt must include scan failure info."""
+        import asyncio
+
+        repo = self._make_tmp_repo(tmp_path)
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        fake_structured = AuditResult(
+            repo="test/repo",
+            profile={"scan_status": "failed"},
+            comparison_markdown="# Test",
+            issues=[],
+        )
+        ctx = self._mock_sdk(monkeypatch, fake_structured)
+
+        def _raise_scan(repo_path):
+            del repo_path
+            raise RuntimeError("scanner tool not found")
+
+        monkeypatch.setattr("gearbox.agents.shared.scanner.scan_repository", _raise_scan)
+
+        _loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_loop)
+        try:
+            _loop.run_until_complete(
+                run_audit(str(repo), output_dir=str(output_dir), enable_prescan=True)
+            )
+        finally:
+            _loop.close()
+
+        system_prompt = ctx.captured_system_prompt[0] if ctx.captured_system_prompt else None
+        assert system_prompt is not None, "system_prompt should have been set"
+        assert "扫描失败" in system_prompt or "扫描未完成" in system_prompt, (
+            f"Prompt must include scan failure info but got: {system_prompt[:500]}"
+        )
+
+    def test_scan_failure_sets_failure_reason_on_result(self, tmp_path: Path, monkeypatch) -> None:
+        """When scan fails and agent returns a result, failure_reason should reflect the scan error."""
+        import asyncio
+
+        repo = self._make_tmp_repo(tmp_path)
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        fake_structured = AuditResult(
+            repo="test/repo",
+            profile={},
+            comparison_markdown="# Test\n",
+            issues=[],
+        )
+        self._mock_sdk(monkeypatch, fake_structured)
+
+        def _raise_scan(repo_path):
+            del repo_path
+            raise RuntimeError("scanner tool not found")
+
+        monkeypatch.setattr("gearbox.agents.shared.scanner.scan_repository", _raise_scan)
+
+        _loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(_loop)
+        try:
+            result = _loop.run_until_complete(
+                run_audit(str(repo), output_dir=str(output_dir), enable_prescan=True)
+            )
+        finally:
+            _loop.close()
+
+        assert result.failure_reason is not None, "failure_reason must be set when scanning fails"
+        assert "scan" in result.failure_reason.lower() or "扫描" in result.failure_reason


### PR DESCRIPTION
## Summary

Fix #92: Propagate scan failure info to agent prompt and AuditResult.failure_reason instead of silently continuing with no scan context.

Changes in `src/gearbox/agents/audit.py`:
1. Track `scan_failure_reason` when `scan_repository()` raises (line 220, 254)
2. Inject scan failure warning into the agent prompt so it knows scanning didn't complete and can annotate `failure_reason` (lines 280-284)
3. Auto-set `structured.failure_reason` with scan error details if the agent didn't set it (lines 351-355)

Tests in `tests/test_audit.py`:
- `test_scan_failure_injected_into_prompt`: Verifies the resolved system_prompt contains "扫描未完成" when scan fails
- `test_scan_failure_sets_failure_reason_on_result`: Verifies `failure_reason` is non-None and contains scan-related text when scan fails

Closes #92