### PR TITLE
feat(#96): Add cost guardrails to audit.yml: reduce cron from hourly (24/day) to twice daily (09:00 & 21:00 UTC), add daily execution limit via gh run list counting (MAX_DAILY_RUNS=2, configurable via AUDIT_MAX_DAILY_RUNS repo var), add commit-based change detection that skips when target repo has no new commits since last successful audit, and gate downstream jobs (audit-run, aggregate-audit) on should_run output while preserving workflow_dispatch/issue_comment bypass. Estimated cost reduction: ~$72–288/month → ~$6/month.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -27,7 +27,7 @@ on:
         type: boolean
 
   schedule:
-    - cron: '0 * * * *'
+    - cron: '0 9,21 * * *'
 
   issue_comment:
     types: [created]
@@ -51,6 +51,7 @@ jobs:
     outputs:
       repo: ${{ steps.target.outputs.repo }}
       matrix_json: ${{ steps.matrix.outputs.matrix_json }}
+      should_run: ${{ steps.cost_guardrail.outputs.should_run }}
     steps:
       - name: Determine target repo
         id: target
@@ -64,6 +65,72 @@ jobs:
             echo "repo=${{ inputs.target_repo }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Cost guardrail — daily budget & change detection
+        id: cost_guardrail
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+          MAX_DAILY_RUNS: ${{ vars.AUDIT_MAX_DAILY_RUNS || '2' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPO="${{ steps.target.outputs.repo }}"
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # 1) Count today's completed audit runs (success or failure both count as executions)
+          RUN_COUNT=$(gh run list \
+            --workflow=audit.yml \
+            --limit 100 \
+            --json status,createdAt,event \
+            --jq "[.[] | select(.event == 'schedule' and (.status == 'completed' or .status == 'in_progress') and (.createdAt | startswith(\"$TODAY\")))] | length" \
+            2>/dev/null || echo "0")
+
+          echo "::group::[guardrail] today's schedule runs = $RUN_COUNT / $MAX_DAILY_RUNS"
+
+          if [ "$RUN_COUNT" -ge "$MAX_DAILY_RUNS" ]; then
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+            echo "skip_reason=Daily limit reached ($RUN_COUNT/$MAX_DAILY_RUNS)" >> "$GITHUB_OUTPUT"
+            echo "::warning::Audit skipped: daily execution limit ($MAX_DAILY_RUNS) already reached"
+            echo "::endgroup::"
+            exit 0
+          fi
+
+          # 2) Check whether target repo has new commits since last successful audit run
+          LAST_SUCCESS=$(gh run list \
+            --workflow=audit.yml \
+            --limit 20 \
+            --json status,createdAt,conclusion \
+            --jq "[.[] | select(.event == 'schedule' and .conclusion == 'success')] | .[0].createdAt" \
+            2>/dev/null || echo "")
+
+          if [ -n "$LAST_SUCCESS" ]; then
+            # Convert ISO timestamp to format expected by gh api (RFC3339)
+            SINCE_ISO=$(python3 -c "
+            from datetime import datetime, timezone
+            dt = datetime.fromisoformat('$LAST_SUCCESS'.replace('Z', '+00:00'))
+            print(dt.isoformat())
+            " 2>/dev/null || echo "$LAST_SUCCESS")
+
+            NEW_COMMITS=$(gh api "repos/$REPO/commits?since=$SINCE_ISO&per_page=1" \
+              --jq '. | length' 2>/dev/null || echo "1")
+
+            if [ "$NEW_COMMITS" -eq 0 ]; then
+              echo "should_run=false" >> "$GITHUB_OUTPUT"
+              echo "skip_reason=No new commits since last audit ($LAST_SUCCESS)" >> "$GITHUB_OUTPUT"
+              echo "::notice::Audit skipped: no new commits in $REPO since $LAST_SUCCESS"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "[guardrail] $NEW_COMMITS new commit(s) since last audit — proceeding"
+          else
+            echo "[guardrail] No previous successful audit found — proceeding with first run"
+          fi
+
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          echo "skip_reason=" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
+
       - name: Checkout
         uses: actions/checkout@v5
 
@@ -75,7 +142,12 @@ jobs:
 
   audit-run:
     needs: plan
-    if: needs.plan.outputs.repo != ''
+    if: |
+      needs.plan.outputs.repo != '' && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'issue_comment' ||
+        (github.event_name == 'schedule' && needs.plan.outputs.should_run == 'true')
+      )
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -109,7 +181,12 @@ jobs:
 
   aggregate-audit:
     needs: [plan, audit-run]
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.repo != '' }}
+    if: |
+      ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.repo != '' }} && (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'issue_comment' ||
+        (github.event_name == 'schedule' && needs.plan.outputs.should_run == 'true')
+      )
     runs-on: ubuntu-latest
     env:
       ANTHROPIC_AUTH_TOKEN: ${{ secrets.ANTHROPIC_AUTH_TOKEN }}

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -328,3 +328,86 @@ class TestAutoMergeWorkflow:
         assert "skip_reason=" in workflow
         assert "::notice::" in workflow
         assert "::warning::" in workflow
+
+
+class TestAuditCostGuardrails:
+    """Verify audit.yml has cost-protection mechanisms for scheduled runs."""
+
+    def test_audit_cron_is_not_hourly(self) -> None:
+        """Cron schedule must not be every hour (0 * * * *)."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # Must NOT contain hourly cron
+        assert "cron: '0 * * * *'" not in workflow
+        # Must contain a cron schedule (not empty)
+        assert re.search(r"cron:\s*'[^\']+'", workflow) is not None
+
+    def test_audit_has_max_daily_runs_limit(self) -> None:
+        """Audit workflow must define a maximum daily execution limit."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # Should reference a daily run limit (env var or hardcoded)
+        assert (
+            "MAX_DAILY_RUNS" in workflow or "max_daily_runs" in workflow or "max_daily" in workflow
+        )
+
+    def test_audit_has_cost_guardrail_step(self) -> None:
+        """Audit plan job must include a cost guardrail / rate-limit step."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # Should have guardrail-related step name or logic
+        assert (
+            "guardrail" in workflow.lower()
+            or "rate.limit" in workflow.lower()
+            or "cost.guard" in workflow.lower()
+            or "daily.budget" in workflow.lower()
+            or "should_run" in workflow
+        )
+
+    def test_audit_guardrail_checks_daily_execution_count(self) -> None:
+        """Guardrail must count today's completed runs to enforce daily limit."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # Should use gh run list to count executions
+        assert "gh run list" in workflow
+
+    def test_audit_guardrail_has_change_detection(self) -> None:
+        """Guardrail should check for recent repo changes before running."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # Should check commits or changes for skip condition
+        assert (
+            "gh api" in workflow
+            and "commits" in workflow
+            or "git log" in workflow
+            or "since" in workflow
+            and "commit" in workflow.lower()
+        )
+
+    def test_audit_guardrail_controls_downstream_jobs(self) -> None:
+        """Downstream jobs must respect the guardrail's should_run output."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # The audit-run job or its upstream dependency should check should_run
+        # Either plan job checks it, or there's an explicit condition
+        assert "should_run" in workflow
+
+    def test_audit_manual_dispatch_bypasses_guardrail(self) -> None:
+        """Manual workflow_dispatch must not be blocked by cost guardrails."""
+        root = _root()
+        workflow = (root / ".github" / "workflows" / "audit.yml").read_text(encoding="utf-8")
+
+        # workflow_dispatch must appear as an independent trigger path, never gated behind should_run
+        assert "workflow_dispatch" in workflow
+        # The audit-run job condition must allow dispatch without checking should_run
+        assert (
+            "github.event_name == 'workflow_dispatch'" in workflow
+            and "github.event_name == 'workflow_dispatch' ||" in workflow
+            or "github.event_name == 'workflow_dispatch' \\" in workflow
+        )


### PR DESCRIPTION
## Summary

Add cost guardrails to audit.yml: reduce cron from hourly (24/day) to twice daily (09:00 & 21:00 UTC), add daily execution limit via gh run list counting (MAX_DAILY_RUNS=2, configurable via AUDIT_MAX_DAILY_RUNS repo var), add commit-based change detection that skips when target repo has no new commits since last successful audit, and gate downstream jobs (audit-run, aggregate-audit) on should_run output while preserving workflow_dispatch/issue_comment bypass. Estimated cost reduction: ~$72–288/month → ~$6/month.

Closes #96