### PR TITLE
feat(#101): Fixed Issue #101: Changed `Issue.labels` schema type from `str` to `list[str]` with `Field(default_factory=list)` to match the downstream `create_issue()` contract in `core/gh.py`. This resolves two failure modes: (1) LLM returning `labels: ["bug", "enhancement"]` (array) no longer causes Pydantic ValidationError that kills the entire AuditResult parse; (2) LLM returning `labels: "bug,enhancement"` (string) is now properly rejected instead of silently passing and causing character-by-character iteration in the label filter. Also updated `load_audit_result()` default and 3 test fixtures that encoded the old string-based pattern. Added 5 new tests validating list semantics, iteration correctness, default behavior, roundtrip serialization, and string rejection.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -107,7 +107,7 @@ def load_audit_result(output_dir: Path) -> AuditResult:
                 {
                     "title": item.get("title", ""),
                     "body": item.get("body", ""),
-                    "labels": item.get("labels", "enhancement"),
+                    "labels": item.get("labels", ["enhancement"]),
                 }
                 for item in issues_payload.get("issues", [])
             ],

--- a/src/gearbox/agents/schemas/audit.py
+++ b/src/gearbox/agents/schemas/audit.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 class Issue(BaseModel):
     title: str
     body: str
-    labels: str
+    labels: list[str] = Field(default_factory=list)
 
 
 class AuditResult(BaseModel):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,12 +53,12 @@ def sample_issues_json() -> dict:
             {
                 "title": "缺少类型注解",
                 "body": "## 问题\n代码缺少类型注解\n\n## 解决方案\n1. 添加 py.typed\n2. 运行 mypy",
-                "labels": "high,enhancement",
+                "labels": ["high", "enhancement"],
             },
             {
                 "title": "测试覆盖不足",
                 "body": "## 问题\n测试覆盖率低于 80%\n\n## 解决方案\n1. 添加 pytest-cov\n2. 补充单元测试",
-                "labels": "medium,testing",
+                "labels": ["medium", "testing"],
             },
         ],
     }

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -50,7 +50,7 @@ class TestStructuredOutputParsing:
                     {
                         "title": "Add type hints",
                         "body": "## Problem",
-                        "labels": "high,enhancement",
+                        "labels": ["high", "enhancement"],
                     }
                 ],
             }
@@ -334,7 +334,7 @@ class TestEvaluatorPrompt:
         results = [
             AuditResult(
                 repo="owner/repo",
-                issues=[AuditIssue(title="A", body="B", labels="high")],
+                issues=[AuditIssue(title="A", body="B", labels=["high"])],
             )
         ]
         prompt = build_evaluation_prompt(results, "Audit 审计结果", ["run_0"])

--- a/tests/test_schema_audit.py
+++ b/tests/test_schema_audit.py
@@ -1,0 +1,57 @@
+"""Tests for audit schema — Issue.labels type correctness."""
+
+from gearbox.agents.schemas.audit import AuditResult, Issue
+
+
+class TestIssueLabelsType:
+    """Verify Issue.labels is list[str] to match downstream gh.create_issue() contract."""
+
+    def test_labels_accepts_list_of_strings(self) -> None:
+        """LLM returning labels as array should parse without ValidationError."""
+        issue = Issue(
+            title="Test issue",
+            body="Test body",
+            labels=["bug", "enhancement"],
+        )
+        assert issue.labels == ["bug", "enhancement"]
+
+    def test_labels_list_iterates_as_elements_not_characters(self) -> None:
+        """Iterating labels must yield label strings, not individual characters."""
+        issue = Issue(
+            title="Test issue",
+            body="Test body",
+            labels=["bug", "security"],
+        )
+        # Downstream code does: [label for label in labels if label in VALID_ISSUE_LABELS]
+        filtered = [label for label in issue.labels if label in {"bug", "security", "enhancement"}]
+        assert filtered == ["bug", "security"]
+        assert len(filtered) == 2  # not 11 (character count)
+
+    def test_labels_default_is_empty_list(self) -> None:
+        """Missing labels should default to empty list, not empty string."""
+        issue = Issue(title="Test", body="Body")
+        assert isinstance(issue.labels, list)
+        assert issue.labels == []
+
+    def test_audit_result_with_list_labels_roundtrips(self) -> None:
+        """Full AuditResult with list labels should serialise and deserialise correctly."""
+        result = AuditResult(
+            repo="owner/repo",
+            issues=[
+                Issue(title="A", body="B", labels=["P0", "security"]),
+                Issue(title="C", body="D", labels=["enhancement"]),
+            ],
+        )
+        data = result.model_dump()
+        restored = AuditResult.model_validate(data)
+        assert restored.issues[0].labels == ["P0", "security"]
+        assert restored.issues[1].labels == ["enhancement"]
+
+    def test_labels_rejects_plain_string(self) -> None:
+        """Passing a comma-separated string like 'bug,enhancement' must NOT silently coerce."""
+        import pytest as pt
+
+        with pt.raises(Exception):  # ValidationError or similar
+            Issue.model_validate(
+                {"title": "T", "body": "B", "labels": "bug,enhancement"}
+            )


### PR DESCRIPTION
## Summary

Fixed Issue #101: Changed `Issue.labels` schema type from `str` to `list[str]` with `Field(default_factory=list)` to match the downstream `create_issue()` contract in `core/gh.py`. This resolves two failure modes: (1) LLM returning `labels: ["bug", "enhancement"]` (array) no longer causes Pydantic ValidationError that kills the entire AuditResult parse; (2) LLM returning `labels: "bug,enhancement"` (string) is now properly rejected instead of silently passing and causing character-by-character iteration in the label filter. Also updated `load_audit_result()` default and 3 test fixtures that encoded the old string-based pattern. Added 5 new tests validating list semantics, iteration correctness, default behavior, roundtrip serialization, and string rejection.

Closes #101