### PR TITLE
feat(#93): Fix #93: Add _truncated marker and severity-based sorting to format_scan_summary()

Changes:
- **scanner.py**: Extracted truncation limits into named constants (_MAX_VULNS=10, _MAX_CODE_ISSUES=15, _MAX_DEP_ISSUES=10). Added _sort_trivy_by_severity() and _sort_semgrep_by_severity() helpers that sort by CRITICAL>HIGH>MEDIUM>LOW (trivy) and ERROR>WARNING>INFO (semgrep) before truncation, so high-severity items are retained. Added _truncated field to payload with booleans for each category indicating whether data was cut.
- **test_scanner.py**: Added 4 TDD tests verifying: _truncated exists with all-False when within limits; _truncated=True when exceeding limits; critical vulnerabilities survive truncation over LOW; error-level semgrep findings survive over INFO.

All 44 scanner tests pass. Ruff clean. Pre-existing test_flow.py failure is unrelated.

### DIFF
--- a/src/gearbox/agents/shared/scanner.py
+++ b/src/gearbox/agents/shared/scanner.py
@@ -366,9 +366,50 @@ def scan_repository(repo_path: Path) -> RepoScanResult:
     return result
 
 
+# Trivy severity order (highest priority first)
+_SEVERITY_ORDER: dict[str, int] = {
+    "CRITICAL": 0,
+    "HIGH": 1,
+    "MEDIUM": 2,
+    "LOW": 3,
+    "UNKNOWN": 4,
+}
+
+# Semgrep severity order (highest priority first)
+_SEMGREP_SEVERITY_ORDER: dict[str, int] = {
+    "ERROR": 0,
+    "WARNING": 1,
+    "INFO": 2,
+}
+
+_MAX_VULNS = 10
+_MAX_CODE_ISSUES = 15
+_MAX_DEP_ISSUES = 10
+
+
+def _sort_trivy_by_severity(vulns: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort trivy vulnerabilities so critical items survive truncation."""
+    return sorted(
+        vulns,
+        key=lambda v: _SEVERITY_ORDER.get(v.get("Severity", "").upper(), 99),
+    )
+
+
+def _sort_semgrep_by_severity(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Sort semgrep findings so high-severity items survive truncation."""
+    return sorted(
+        findings,
+        key=lambda f: _SEMGREP_SEVERITY_ORDER.get(f.get("severity", "").upper(), 99),
+    )
+
+
 def format_scan_summary(scan: RepoScanResult) -> str:
     """将扫描结果格式化为 JSON（供 Agent 直接解析）"""
     import json
+
+    # Sort by severity before truncating so high-priority items are retained
+    sorted_vulns = _sort_trivy_by_severity(scan.trivy_vulnerabilities)
+    sorted_findings = _sort_semgrep_by_severity(scan.semgrep_findings)
 
     payload: dict[str, Any] = {
         "project_type": scan.project_type,
@@ -390,7 +431,7 @@ def format_scan_summary(scan: RepoScanResult) -> str:
                 "severity": v.get("Severity", ""),
                 "title": v.get("Title", v.get("Description", ""))[:80],
             }
-            for v in scan.trivy_vulnerabilities[:10]
+            for v in sorted_vulns[:_MAX_VULNS]
         ],
         "govulncheck_vulns": [
             {
@@ -405,15 +446,20 @@ def format_scan_summary(scan: RepoScanResult) -> str:
                 "rule": f.get("check_id", ""),
                 "message": f.get("message", "")[:100],
             }
-            for f in scan.semgrep_findings[:15]
+            for f in sorted_findings[:_MAX_CODE_ISSUES]
         ],
         "dependency_issues": [
             {
                 "type": i.get("type", i.get("error", {}).get("code", "")),
                 "message": i.get("message", i.get("error", {}).get("message", ""))[:100],
             }
-            for i in scan.deptry_issues[:10]
+            for i in scan.deptry_issues[:_MAX_DEP_ISSUES]
         ],
+        "_truncated": {
+            "vulnerabilities": len(scan.trivy_vulnerabilities) > _MAX_VULNS,
+            "code_issues": len(scan.semgrep_findings) > _MAX_CODE_ISSUES,
+            "dependency_issues": len(scan.deptry_issues) > _MAX_DEP_ISSUES,
+        },
         "_stats": {
             "total_vulnerabilities": len(scan.trivy_vulnerabilities),
             "total_code_issues": len(scan.semgrep_findings),

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -478,6 +478,84 @@ class TestFormatScanSummary:
         assert output["_stats"]["scanned_tools"]["trivy"] is True
         assert output["_stats"]["scanned_tools"]["deptry"] is True
 
+    def test_truncated_field_present_when_within_limits(self) -> None:
+        """When counts are within limits, _truncated should exist with all False."""
+        scan = self._base_scan()
+        # Base scan has 2 vulns, 2 findings, 1 dep issue — all under limits
+        output = json.loads(format_scan_summary(scan))
+
+        assert "_truncated" in output
+        assert output["_truncated"]["vulnerabilities"] is False
+        assert output["_truncated"]["code_issues"] is False
+        assert output["_truncated"]["dependency_issues"] is False
+
+    def test_truncated_field_true_when_exceeding_limits(self) -> None:
+        """When counts exceed limits, _truncated should flag which sections were cut."""
+        scan = self._base_scan()
+        scan.trivy_vulnerabilities = [
+            {"VulnerabilityID": f"V-{i}", "Severity": "HIGH", "Title": f"vuln {i}"}
+            for i in range(15)
+        ]
+        scan.semgrep_findings = [
+            {"id": f"S-{i}", "severity": "WARNING", "message": f"finding {i}"}
+            for i in range(20)
+        ]
+        scan.deptry_issues = [
+            {"type": "deprecated", "error": {"code": f"D-{i}", "message": f"dep {i}"}}
+            for i in range(12)
+        ]
+        output = json.loads(format_scan_summary(scan))
+
+        assert output["_truncated"]["vulnerabilities"] is True
+        assert output["_truncated"]["code_issues"] is True
+        assert output["_truncated"]["dependency_issues"] is True
+
+    def test_truncation_sorts_vulnerabilities_by_severity(self) -> None:
+        """Critical vulnerabilities should be retained over LOW when truncated."""
+        scan = self._base_scan()
+        # Create 15 vulns: 5 CRITICAL at end, 10 LOW at start — without sort, LOW wins
+        vulns = []
+        for i in range(10):
+            vulns.append(
+                {"VulnerabilityID": f"LOW-{i}", "Severity": "LOW", "Title": f"low {i}"}
+            )
+        for i in range(5):
+            vulns.append(
+                {
+                    "VulnerabilityID": f"CRIT-{i}",
+                    "Severity": "CRITICAL",
+                    "Title": f"critical {i}",
+                }
+            )
+        scan.trivy_vulnerabilities = vulns
+        output = json.loads(format_scan_summary(scan))
+
+        displayed_ids = [v["id"] for v in output["vulnerabilities"]]
+        # All 5 CRITICAL must be present in the top-10 result
+        for i in range(5):
+            assert f"CRIT-{i}" in displayed_ids
+
+    def test_truncation_sorts_code_issues_by_severity(self) -> None:
+        """High-severity semgrep findings should be retained over INFO when truncated."""
+        scan = self._base_scan()
+        findings = []
+        # 20 INFO findings first, then 5 ERROR findings
+        for i in range(20):
+            findings.append(
+                {"check_id": f"INFO-{i}", "severity": "info", "message": f"info {i}"}
+            )
+        for i in range(5):
+            findings.append(
+                {"check_id": f"ERR-{i}", "severity": "error", "message": f"err {i}"}
+            )
+        scan.semgrep_findings = findings
+        output = json.loads(format_scan_summary(scan))
+
+        displayed_ids = [f["rule"] for f in output["code_issues"]]
+        # All 5 ERROR findings must survive truncation to 15
+        for i in range(5):
+            assert f"ERR-{i}" in displayed_ids
+
 
 # ---------------------------------------------------------------------------
 # _fallback_file_counts


### PR DESCRIPTION
## Summary

Fix #93: Add _truncated marker and severity-based sorting to format_scan_summary()

Changes:
- **scanner.py**: Extracted truncation limits into named constants (_MAX_VULNS=10, _MAX_CODE_ISSUES=15, _MAX_DEP_ISSUES=10). Added _sort_trivy_by_severity() and _sort_semgrep_by_severity() helpers that sort by CRITICAL>HIGH>MEDIUM>LOW (trivy) and ERROR>WARNING>INFO (semgrep) before truncation, so high-severity items are retained. Added _truncated field to payload with booleans for each category indicating whether data was cut.
- **test_scanner.py**: Added 4 TDD tests verifying: _truncated exists with all-False when within limits; _truncated=True when exceeding limits; critical vulnerabilities survive truncation over LOW; error-level semgrep findings survive over INFO.

All 44 scanner tests pass. Ruff clean. Pre-existing test_flow.py failure is unrelated.

Closes #93