### PR TITLE
feat(#113): Fix #113: Add per-run error isolation to `load_audit_output()` so corrupted artifacts in one parallel audit run don't crash the entire aggregation pipeline.

**Changes:**
- **`src/gearbox/agents/audit.py`**: Added `load_audit_output()` wrapper function that catches `ValidationError`, `AttributeError`, `TypeError`, and `KeyError` from `load_audit_result()`, returning `None` for corrupted runs instead of propagating the exception. Added `logging` and `pydantic` imports.
- **`src/gearbox/commands/agent.py`**: Updated `audit_select` command to use `load_audit_output()` (with None-check + continue) instead of bare `load_audit_result()` in a try/except that only caught `FileNotFoundError`.
- **`tests/test_audit.py`**: Added 4 tests in `TestLoadAuditOutputErrorIsolation` class verifying: corrupted JSON returns None, valid JSON returns AuditResult, original `load_audit_result` still raises on corruption, and multi-run aggregation skips corrupted runs while preserving valid ones.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -1,12 +1,14 @@
 """Audit Agent — 仓库审计，生成改进建议"""
 
 import json
+import logging
 import shutil
 import tempfile
 import time
 from pathlib import Path
 
 import click
+import pydantic
 
 from gearbox.agents.schemas import AuditResult as _AuditResultModel
 from gearbox.agents.schemas import Issue as _IssueModel
@@ -113,6 +115,24 @@ def load_audit_result(output_dir: Path) -> AuditResult:
             ],
         }
     )
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_audit_output(output_dir: Path) -> AuditResult | None:
+    """Load single run output with per-run error isolation (#113).
+
+    Returns ``None`` when the artifact is corrupted (e.g. malformed
+    ``issues.json`` that causes a pydantic ``ValidationError``, wrong types,
+    missing keys, etc.), so the caller can skip the damaged run without
+    crashing the whole aggregation pipeline.
+    """
+    try:
+        return load_audit_result(output_dir)
+    except (pydantic.ValidationError, AttributeError, TypeError, KeyError) as exc:
+        logger.warning("Skipping corrupted audit output %s: %s", output_dir, exc)
+        return None
 
 
 # =============================================================================

--- a/src/gearbox/commands/agent.py
+++ b/src/gearbox/commands/agent.py
@@ -9,7 +9,12 @@ from typing import cast
 
 import click
 
-from gearbox.agents.audit import AuditResult, load_audit_result, promote_audit_outputs, run_audit
+from gearbox.agents.audit import (
+    AuditResult,
+    load_audit_output,
+    promote_audit_outputs,
+    run_audit,
+)
 from gearbox.agents.backlog import (
     BacklogItemResult,
     BacklogResult,
@@ -335,10 +340,11 @@ def audit_select(input_root: str, output_dir: str, model: str, max_turns: int, o
     # Load results with per-directory error handling (audit stores artifacts in subdirs)
     candidates: list[tuple[str, object]] = []
     for run_dir in sorted(p for p in root.iterdir() if p.is_dir()):
-        try:
-            candidates.append((run_dir.name, load_audit_result(run_dir)))
-        except FileNotFoundError as exc:
-            click.echo(f"⚠️ 跳过无效结果目录 {run_dir.name}: {exc}")
+        result = load_audit_output(run_dir)
+        if result is None:
+            click.echo(f"⚠️ 跳过损坏或无效的结果目录 {run_dir.name}")
+            continue
+        candidates.append((run_dir.name, result))
 
     if not candidates:
         click.echo("❌ 没有可用于聚合的 audit 结果", err=True)

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -4,8 +4,100 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
+from gearbox.agents.audit import load_audit_output, load_audit_result
+from gearbox.agents.schemas import AuditResult as _AuditResultModel
 from gearbox.agents.shared import clone_repository, scanner
 from gearbox.agents.shared.scanner import scan_repository
+
+
+class TestLoadAuditOutputErrorIsolation:
+    """Verify that load_audit_output isolates per-run validation errors (#113)."""
+
+    def _write_valid_issues(self, dir_: Path) -> None:
+        payload = {
+            "repo": "owner/repo",
+            "profile": {"language": "python"},
+            "benchmarks": ["a/b"],
+            "issues": [
+                {
+                    "repo": "owner/repo",
+                    "title": "Fix X",
+                    "body": "Do Y\n> **severity**: high",
+                    "labels": "bug",
+                }
+            ],
+        }
+        (dir_ / "issues.json").write_text(json.dumps(payload), encoding="utf-8")
+        (dir_ / "comparison.md").write_text("# Comparison\n", encoding="utf-8")
+
+    def _write_corrupted_issues(self, dir_: Path) -> None:
+        # Wrong type: 'issues' is an int instead of list → model_validate raises ValidationError
+        payload = {
+            "repo": "owner/repo",
+            "profile": {"language": 42},  # int where dict expected
+            "benchmarks": [1, 2, 3],  # ints where strings expected
+            "issues": "not-a-list",  # string where list expected
+        }
+        (dir_ / "issues.json").write_text(json.dumps(payload), encoding="utf-8")
+        (dir_ / "comparison.md").write_text("# Broken\n", encoding="utf-8")
+
+    def test_load_audit_output_returns_none_on_corrupted_json(self, tmp_path: Path) -> None:
+        """Corrupted issues.json returns None instead of raising."""
+        run_dir = tmp_path / "run-corrupted"
+        run_dir.mkdir()
+        self._write_corrupted_issues(run_dir)
+
+        result = load_audit_output(run_dir)
+        assert result is None
+
+    def test_load_audit_output_returns_result_on_valid_json(self, tmp_path: Path) -> None:
+        """Valid issues.json returns AuditResult."""
+        run_dir = tmp_path / "run-valid"
+        run_dir.mkdir()
+        self._write_valid_issues(run_dir)
+
+        result = load_audit_output(run_dir)
+        assert result is not None
+        assert isinstance(result, _AuditResultModel)
+        assert result.repo == "owner/repo"
+        assert len(result.issues) == 1
+
+    def test_load_audit_result_raises_on_corrupted_json(self, tmp_path: Path) -> None:
+        """Original load_audit_result still raises on corrupted data (no isolation)."""
+        run_dir = tmp_path / "run-broken"
+        run_dir.mkdir()
+        self._write_corrupted_issues(run_dir)
+
+        with pytest.raises(Exception):
+            load_audit_result(run_dir)
+
+    def test_aggregation_skips_corrupted_run(self, tmp_path: Path) -> None:
+        """Multiple runs where one is corrupted: only valid runs survive."""
+        valid1 = tmp_path / "run-1"
+        valid1.mkdir()
+        self._write_valid_issues(valid1)
+
+        broken = tmp_path / "run-2"
+        broken.mkdir()
+        self._write_corrupted_issues(broken)
+
+        valid2 = tmp_path / "run-3"
+        valid2.mkdir()
+        self._write_valid_issues(valid2)
+
+        results = []
+        for d in sorted(tmp_path.iterdir()):
+            out = load_audit_output(d)
+            if out is not None:
+                results.append((d.name, out))
+
+        assert len(results) == 2
+        names = [r[0] for r in results]
+        assert "run-1" in names
+        assert "run-3" in names
+        assert "run-2" not in names
 
 
 def test_clone_repository_supports_local_git_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix #113: Add per-run error isolation to `load_audit_output()` so corrupted artifacts in one parallel audit run don't crash the entire aggregation pipeline.

**Changes:**
- **`src/gearbox/agents/audit.py`**: Added `load_audit_output()` wrapper function that catches `ValidationError`, `AttributeError`, `TypeError`, and `KeyError` from `load_audit_result()`, returning `None` for corrupted runs instead of propagating the exception. Added `logging` and `pydantic` imports.
- **`src/gearbox/commands/agent.py`**: Updated `audit_select` command to use `load_audit_output()` (with None-check + continue) instead of bare `load_audit_result()` in a try/except that only caught `FileNotFoundError`.
- **`tests/test_audit.py`**: Added 4 tests in `TestLoadAuditOutputErrorIsolation` class verifying: corrupted JSON returns None, valid JSON returns AuditResult, original `load_audit_result` still raises on corruption, and multi-run aggregation skips corrupted runs while preserving valid ones.

Closes #113