### PR TITLE
feat(#118): Fix #118: Make `_write_audit_outputs()` write audit output files (profile.json, issues.json, comparison.md) atomically using a staging directory + `os.replace()` pattern. Previously, three direct `.write_text()` calls meant a process kill between any two writes would leave an inconsistent artifact set. Now all files are written to a temp staging dir first, then atomically moved to the target location only after all writes succeed. Added 7 new tests covering atomicity mechanism, content correctness, and no-partial-write guarantees.

### DIFF
--- a/src/gearbox/agents/audit.py
+++ b/src/gearbox/agents/audit.py
@@ -1,6 +1,7 @@
 """Audit Agent — 仓库审计，生成改进建议"""
 
 import json
+import os
 import shutil
 import tempfile
 import time
@@ -24,7 +25,11 @@ _BENCHMARK_CACHE_DIR = Path.home() / ".cache" / "gearbox" / "benchmarks"
 
 
 def _write_audit_outputs(result: AuditResult, output_dir: Path) -> None:
-    """由宿主进程统一写出 audit 产物文件。"""
+    """由宿主进程统一写出 audit 产物文件（原子写入）。
+
+    所有产物先写入临时目录，全部完成后通过 os.replace() 原子性移至目标位置，
+    确保不会出现部分更新的不一致状态。
+    """
     output_dir.mkdir(parents=True, exist_ok=True)
 
     issues_payload = {
@@ -42,18 +47,29 @@ def _write_audit_outputs(result: AuditResult, output_dir: Path) -> None:
         ],
     }
 
-    (output_dir / "issues.json").write_text(
-        json.dumps(issues_payload, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-    (output_dir / "profile.json").write_text(
-        json.dumps(result.profile, ensure_ascii=False, indent=2),
-        encoding="utf-8",
-    )
-    comparison_markdown = result.comparison_markdown.strip()
-    if not comparison_markdown:
-        comparison_markdown = "# Audit Comparison\n\nNo comparison markdown returned."
-    (output_dir / "comparison.md").write_text(comparison_markdown + "\n", encoding="utf-8")
+    # Phase 1: write all files to a staging directory
+    staging = tempfile.mkdtemp(dir=output_dir, prefix=".audit_tmp_")
+    staging_path = Path(staging)
+
+    try:
+        (staging_path / "issues.json").write_text(
+            json.dumps(issues_payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        (staging_path / "profile.json").write_text(
+            json.dumps(result.profile, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        comparison_markdown = result.comparison_markdown.strip()
+        if not comparison_markdown:
+            comparison_markdown = "# Audit Comparison\n\nNo comparison markdown returned."
+        (staging_path / "comparison.md").write_text(comparison_markdown + "\n", encoding="utf-8")
+
+        # Phase 2: atomically move each file to the final location
+        for name in OUTPUT_FILES:
+            os.replace(str(staging_path / name), str(output_dir / name))
+    finally:
+        shutil.rmtree(staging_path, ignore_errors=True)
 
 
 def _get_cached_benchmarks(repo: str, language: str | None = None) -> list[str] | None:

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,11 +1,119 @@
 """Tests for audit helpers."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
+from gearbox.agents.audit import OUTPUT_FILES, AuditResult, Issue, _write_audit_outputs
 from gearbox.agents.shared import clone_repository, scanner
 from gearbox.agents.shared.scanner import scan_repository
+
+
+def _make_sample_result() -> AuditResult:
+    return AuditResult(
+        repo="owner/repo",
+        profile={"language": "Python", "files": 10},
+        comparison_markdown="# Comparison\n\nSome analysis.",
+        benchmarks=["benchmark/repo"],
+        issues=[
+            Issue(
+                title="Test issue",
+                body="Test body\n> **severity**: high",
+                labels="enhancement",
+            )
+        ],
+    )
+
+
+class TestWriteAuditOutputsAtomic:
+    """Verify _write_audit_outputs writes all three files atomically."""
+
+    def test_writes_all_three_output_files(self, tmp_path: Path) -> None:
+        result = _make_sample_result()
+        _write_audit_outputs(result, tmp_path)
+
+        for name in OUTPUT_FILES:
+            assert (tmp_path / name).exists(), f"Missing output file: {name}"
+
+    def test_issues_json_content(self, tmp_path: Path) -> None:
+        result = _make_sample_result()
+        _write_audit_outputs(result, tmp_path)
+
+        data = json.loads((tmp_path / "issues.json").read_text(encoding="utf-8"))
+        assert data["repo"] == "owner/repo"
+        assert data["profile"]["language"] == "Python"
+        assert len(data["issues"]) == 1
+        assert data["issues"][0]["title"] == "Test issue"
+
+    def test_profile_json_content(self, tmp_path: Path) -> None:
+        result = _make_sample_result()
+        _write_audit_outputs(result, tmp_path)
+
+        data = json.loads((tmp_path / "profile.json").read_text(encoding="utf-8"))
+        assert data["language"] == "Python"
+        assert data["files"] == 10
+
+    def test_comparison_md_content(self, tmp_path: Path) -> None:
+        result = _make_sample_result()
+        _write_audit_outputs(result, tmp_path)
+
+        content = (tmp_path / "comparison.md").read_text(encoding="utf-8")
+        assert content.startswith("# Comparison")
+        assert "Some analysis." in content
+
+    def test_comparison_md_fallback_when_empty(self, tmp_path: Path) -> None:
+        result = _make_sample_result()
+        result.comparison_markdown = ""
+        _write_audit_outputs(result, tmp_path)
+
+        content = (tmp_path / "comparison.md").read_text(encoding="utf-8")
+        assert "No comparison markdown returned." in content
+
+    def test_atomic_write_uses_temp_dir_and_replace(self, tmp_path: Path) -> None:
+        """Verify files are written via temp dir + os.replace for atomicity."""
+        result = _make_sample_result()
+
+        replace_calls: list[tuple[Path, Path]] = []
+        orig_replace = os.replace
+
+        def tracking_replace(src: str | os.PathLike[str], dst: str | os.PathLike[str]) -> None:
+            replace_calls.append((Path(src), Path(dst)))
+            orig_replace(src, dst)
+
+        with patch("os.replace", side_effect=tracking_replace):
+            _write_audit_outputs(result, tmp_path)
+
+        # All three output files must be moved atomically via os.replace
+        replaced_names = {call[1].name for call in replace_calls}
+        assert replaced_names == set(OUTPUT_FILES), (
+            f"Expected os.replace for {set(OUTPUT_FILES)}, got {replaced_names}"
+        )
+
+    def test_no_partial_write_on_success(self, tmp_path: Path) -> None:
+        """After a successful call, all three files must represent the same result."""
+        old_result = AuditResult(
+            repo="old/repo",
+            profile={"language": "Go"},
+            comparison_markdown="# Old",
+            issues=[Issue(title="Old", body="old", labels="bug")],
+        )
+        new_result = _make_sample_result()
+
+        # Write old data first
+        _write_audit_outputs(old_result, tmp_path)
+        # Write new data — must fully replace old
+        _write_audit_outputs(new_result, tmp_path)
+
+        issues_data = json.loads((tmp_path / "issues.json").read_text(encoding="utf-8"))
+        profile_data = json.loads((tmp_path / "profile.json").read_text(encoding="utf-8"))
+        comparison = (tmp_path / "comparison.md").read_text(encoding="utf-8")
+
+        # All three files must reflect the NEW result, not a mix
+        assert issues_data["repo"] == "owner/repo"
+        assert profile_data["language"] == "Python"
+        assert "# Comparison" in comparison
 
 
 def test_clone_repository_supports_local_git_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fix #118: Make `_write_audit_outputs()` write audit output files (profile.json, issues.json, comparison.md) atomically using a staging directory + `os.replace()` pattern. Previously, three direct `.write_text()` calls meant a process kill between any two writes would leave an inconsistent artifact set. Now all files are written to a temp staging dir first, then atomically moved to the target location only after all writes succeed. Added 7 new tests covering atomicity mechanism, content correctness, and no-partial-write guarantees.

Closes #118